### PR TITLE
cmd/tgfeed: enable profiling and debug logging

### DIFF
--- a/cmd/tgfeed/tgfeed.service
+++ b/cmd/tgfeed/tgfeed.service
@@ -9,7 +9,7 @@ After=network-online.target
 Type=oneshot
 
 # Path to the tgfeed binary.
-ExecStart=/srv/tgfeed/current/bin/tgfeed run
+ExecStart=/srv/tgfeed/current/bin/tgfeed -cpuprofile %S/tgfeed/cpu.pprof -memprofile %S/tgfeed/mem.pprof -log-level debug run
 
 # Load secrets from a configuration file.
 EnvironmentFile=/etc/tgfeed.conf


### PR DESCRIPTION
Update the systemd service unit to execute `tgfeed` with CPU and memory profiling enabled, saving the profiles to the state directory. Additionally, increase the log level to `debug` to assist with troubleshooting and performance analysis.
