### PR TITLE
cmd/tgfeed: fix format string bug when printing diff

### DIFF
--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -268,7 +268,7 @@ func (f *fetcher) edit(ctx context.Context) error {
 		}
 
 		f.logf("You've made these changes:")
-		f.logf(string(diff.Diff("old", []byte(f.config), "new", edited)))
+		f.logf("%s", diff.Diff("old", []byte(f.config), "new", edited))
 		if !f.ask("Do you want to save?", env.Stdin) {
 			return nil
 		}


### PR DESCRIPTION
The previous code passed the output of diff.Diff directly as the
format string to f.logf. This is incorrect and could lead to a format
string bug.

If the generated diff contained any printf-style format specifiers
(e.g., `%s`, `%d`), they would be interpreted by the logging function,
leading to corrupted output like `%!s(MISSING)`.
