### PR TITLE
Handle retrospective feed updates in tgfeed

### DIFF
--- a/cmd/tgfeed/doc.go
+++ b/cmd/tgfeed/doc.go
@@ -62,12 +62,19 @@ This file is written in Starlark language and defines a list of feeds, for examp
 	    message_thread_id=123, # Send updates to a specific topic.
 	    digest=True, # Bundle updates into a single message.
 	    format=lambda items: "Digest: " + str(len(items)) + " items", # Custom format.
+	    always_send_new_items=True, # Send items even if they have an old publication date.
 	)
 
 Each feed can have a title, URL, and optional block and keep rules.
 Optionally, message_thread_id can be specified to send updates from this
 feed to a specific message thread (topic) within the chat. This is applicable
 only for supergroups with topics enabled.
+
+If always_send_new_items is set to true, tgfeed will send items even if they
+have a publication date in the past. This is useful for feeds that add items
+retrospectively, like CourtListener docket feeds. To avoid duplicates, tgfeed
+tracks seen items in its state. Only items published within the last 14 days
+are considered.
 
 Digest mode can be enabled by setting digest to true. In this mode, updates
 are bundled into a single message instead of sending one message per item.

--- a/cmd/tgfeed/state.go
+++ b/cmd/tgfeed/state.go
@@ -33,13 +33,14 @@ import (
 // Feed state.
 
 type feed struct {
-	url             string
-	title           string
-	messageThreadID int64
-	blockRule       *starlark.Function
-	keepRule        *starlark.Function
-	digest          bool
-	format          *starlark.Function
+	url                string
+	title              string
+	messageThreadID    int64
+	blockRule          *starlark.Function
+	keepRule           *starlark.Function
+	digest             bool
+	format             *starlark.Function
+	alwaysSendNewItems bool
 }
 
 func newFeedBuiltin(feeds *[]*feed) *starlark.Builtin {
@@ -56,6 +57,7 @@ func newFeedBuiltin(feeds *[]*feed) *starlark.Builtin {
 			"keep_rule?", &f.keepRule,
 			"digest?", &f.digest,
 			"format?", &f.format,
+			"always_send_new_items?", &f.alwaysSendNewItems,
 		); err != nil {
 			return nil, err
 		}
@@ -71,6 +73,11 @@ type feedState struct {
 	ETag         string    `json:"etag,omitempty"`
 	ErrorCount   int       `json:"error_count,omitempty"`
 	LastError    string    `json:"last_error,omitempty"`
+
+	// SeenItems tracks processed items for feeds with always_send_new_items
+	// enabled. The key is the item GUID and the value is the time it was first
+	// seen.
+	SeenItems map[string]time.Time `json:"seen_items,omitempty"`
 
 	// Stats.
 	FetchCount     int64 `json:"fetch_count"`      // successful fetches

--- a/cmd/tgfeed/testdata/always_send_new_items/config.star
+++ b/cmd/tgfeed/testdata/always_send_new_items/config.star
@@ -1,0 +1,1 @@
+feed(url="https://example.com/feed.xml", always_send_new_items=True)

--- a/cmd/tgfeed/testdata/always_send_new_items/config.star
+++ b/cmd/tgfeed/testdata/always_send_new_items/config.star
@@ -1,1 +1,5 @@
+# © 2026 Ilya Mateyko. All rights reserved.
+# Use of this source code is governed by the ISC
+# license that can be found in the LICENSE.md file.
+
 feed(url="https://example.com/feed.xml", always_send_new_items=True)

--- a/cmd/tgfeed/testdata/always_send_new_items/feed1.xml.tmpl
+++ b/cmd/tgfeed/testdata/always_send_new_items/feed1.xml.tmpl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Feed</title>
+  <entry>
+    <title>Recent but old date</title>
+    <link href="http://example.com/item1"/>
+    <id>item1</id>
+    <published>%s</published>
+  </entry>
+  <entry>
+    <title>Too old</title>
+    <link href="http://example.com/item2"/>
+    <id>item2</id>
+    <published>%s</published>
+  </entry>
+</feed>

--- a/cmd/tgfeed/testdata/always_send_new_items/feed2.xml.tmpl
+++ b/cmd/tgfeed/testdata/always_send_new_items/feed2.xml.tmpl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Feed</title>
+  <entry>
+    <title>Recent but old date</title>
+    <link href="http://example.com/item1"/>
+    <id>item1</id>
+    <published>%s</published>
+  </entry>
+  <entry>
+    <title>New item with old date</title>
+    <link href="http://example.com/item3"/>
+    <id>item3</id>
+    <published>%s</published>
+  </entry>
+</feed>


### PR DESCRIPTION
Fixed the issue where retrospective updates in CourtListener's RSS feeds were being ignored by tgfeed because they had an old publication date.

Changes:
- Added `always_send_new_items` flag to the `feed` Starlark function.
- Added `SeenItems` to the feed state to track processed items.
- Implemented filtering logic in `fetch.go` that uses `SeenItems` and a 14-day lookback period when the flag is enabled.
- Added a nil check for `PublishedParsed` to prevent panics.
- Documented the new feature in `doc.go`.
- Added a new test case `TestAlwaysSendNewItems` and associated test data in `testdata`.

Verification:
- All existing tests passed.
- New test case `TestAlwaysSendNewItems` correctly verifies that retrospective updates are processed while duplicates and very old items are skipped.

---
*PR created automatically by Jules for task [7638751731851604071](https://jules.google.com/task/7638751731851604071) started by @astrophena*