### PR TITLE
cmd/tgfeed: clean up legacy and unused test code

### DIFF
--- a/cmd/tgfeed/admin_test.go
+++ b/cmd/tgfeed/admin_test.go
@@ -95,16 +95,6 @@ func TestAdmin(t *testing.T) {
 		"stats/b.json": {Data: []byte(`{"start_time":"2023-01-02T12:00:00Z"}`)},
 	}
 
-	t.Run("root redirect", func(t *testing.T) {
-		f := setup(t, nil)
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		w := httptest.NewRecorder()
-		f.admin(t.Context())
-		http.Redirect(w, req, "/debug/", http.StatusFound)
-		testutil.AssertEqual(t, w.Code, http.StatusFound)
-		testutil.AssertEqual(t, w.Header().Get("Location"), "/debug/")
-	})
-
 	t.Run("get config", func(t *testing.T) {
 		f := setup(t, initialFS)
 		req := httptest.NewRequest(http.MethodGet, "/api/config", nil)


### PR DESCRIPTION
Clean up legacy and unused test code in `cmd/tgfeed`.

- Remove unused Google Sheets integration mock from `main_test.go`.
- Remove broken `root redirect` test case from `admin_test.go`.

---
*PR created automatically by Jules for task [14649727208245483495](https://jules.google.com/task/14649727208245483495) started by @astrophena*