### PR TITLE
cmd/mdserve: escape HTML in image transformation

### DIFF
--- a/cmd/mdserve/main.go
+++ b/cmd/mdserve/main.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"html"
 	"html/template"
 	"io/fs"
 	"log/slog"
@@ -273,8 +274,8 @@ func transformImageBlock(b markdown.Block) markdown.Block {
 	return &markdown.HTMLBlock{
 		Text: []string{
 			"<figure>",
-			fmt.Sprintf(`<img src="%s" alt="%s" title="%s">`, img.URL, alt, img.Title),
-			fmt.Sprintf("<figcaption>%s</figcaption>", alt),
+			fmt.Sprintf(`<img src="%s" alt="%s" title="%s">`, html.EscapeString(img.URL), html.EscapeString(alt), html.EscapeString(img.Title)),
+			fmt.Sprintf("<figcaption>%s</figcaption>", html.EscapeString(alt)),
 			"</figure>",
 		},
 	}


### PR DESCRIPTION
🎯 **What:** Fixed a Stored XSS vulnerability in the Markdown image transformation logic in `cmd/mdserve/main.go`.
⚠️ **Risk:** User-controlled strings (image URL, alt text, and title) were being injected into HTML attributes without escaping, allowing for attribute breakout and arbitrary HTML/JS injection.
🛡️ **Solution:** Used `html.EscapeString` to properly escape all user-controlled variables before they are formatted into the HTML output.

---
*PR created automatically by Jules for task [15114404236709153690](https://jules.google.com/task/15114404236709153690) started by @astrophena*