### PR TITLE
cmd/tgfeed: validate formatter return types

### DIFF
--- a/cmd/tgfeed/fetch.go
+++ b/cmd/tgfeed/fetch.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	urlpkg "net/url"
 	"regexp"
@@ -356,136 +357,13 @@ var nonAlphaNumRe = sync.OnceValue(func() *regexp.Regexp {
 })
 
 func (f *fetcher) sendUpdate(ctx context.Context, u *update) {
-	var (
-		msg          string
-		replyMarkup  *inlineKeyboard
-		items        starlark.Value
-		defaultTitle string
-	)
-
-	// Prepare items for Starlark or default formatting.
-	if u.feed.digest {
-		var list []starlark.Value
-		for _, item := range u.items {
-			list = append(list, f.itemToStarlark(item))
-		}
-		items = starlark.NewList(list)
-		defaultTitle = fmt.Sprintf("Updates from %s", u.feed.title)
-		if u.feed.title == "" {
-			defaultTitle = fmt.Sprintf("Updates from %s", u.feed.url)
-		}
-	} else {
-		items = f.itemToStarlark(u.items[0])
-		defaultTitle = u.items[0].Title
-		if defaultTitle == "" {
-			defaultTitle = u.items[0].Link
-		}
-	}
-
-	// Use custom format if defined, otherwise fall back to default.
-	if u.feed.format != nil {
-		val, err := starlark.Call(
-			&starlark.Thread{
-				Print: func(_ *starlark.Thread, msg string) { f.slog.Info(msg) },
-			},
-			u.feed.format,
-			starlark.Tuple{items},
-			[]starlark.Tuple{},
+	msg, replyMarkup, err := f.buildUpdateMessage(u)
+	if err != nil {
+		f.slog.Warn("building update message failed",
+			slog.String("feed", u.feed.url),
+			slog.Any("error", err),
 		)
-		if err != nil {
-			f.slog.Warn("formatting message", "feed", u.feed.url, "error", err)
-			return
-		}
-
-		switch v := val.(type) {
-		case starlark.String:
-			msg = v.GoString()
-		case starlark.Tuple:
-			if len(v) >= 1 {
-				if s, ok := v[0].(starlark.String); ok {
-					msg = s.GoString()
-				}
-			}
-			if len(v) >= 2 {
-				if k, ok := v[1].(*starlark.List); ok {
-					rows := make([][]inlineKeyboardButton, 0, k.Len())
-					iter := k.Iterate()
-					var rowValue starlark.Value
-					for iter.Next(&rowValue) {
-						if rowList, ok := rowValue.(*starlark.List); ok {
-							buttons := make([]inlineKeyboardButton, 0, rowList.Len())
-							rowIter := rowList.Iterate()
-							var buttonValue starlark.Value
-							for rowIter.Next(&buttonValue) {
-								if buttonDict, ok := buttonValue.(*starlark.Dict); ok {
-									var btn inlineKeyboardButton
-									for _, item := range buttonDict.Items() {
-										key, ok1 := item[0].(starlark.String)
-										val, ok2 := item[1].(starlark.String)
-										if ok1 && ok2 {
-											switch key.GoString() {
-											case "text":
-												btn.Text = val.GoString()
-											case "url":
-												btn.URL = val.GoString()
-											}
-										}
-									}
-									if btn.Text != "" && btn.URL != "" {
-										buttons = append(buttons, btn)
-									}
-								}
-							}
-							if len(buttons) > 0 {
-								rows = append(rows, buttons)
-							}
-						}
-					}
-					iter.Done()
-					if len(rows) > 0 {
-						kb := inlineKeyboard(rows)
-						replyMarkup = &kb
-					}
-				}
-			}
-		default:
-			f.slog.Warn("format function returned unexpected type", "feed", u.feed.url, "type", val.Type())
-			return
-		}
-	} else {
-		// Default formatting.
-		if u.feed.digest {
-			var sb strings.Builder
-			fmt.Fprintf(&sb, "<b>%s</b>\n\n", defaultTitle)
-			for _, item := range u.items {
-				title := item.Title
-				if title == "" {
-					title = item.Link
-				}
-				fmt.Fprintf(&sb, "• <a href=%q>%s</a>\n", item.Link, title)
-			}
-			msg = sb.String()
-		} else {
-			msg = fmt.Sprintf(messageTemplate, defaultTitle, u.items[0].Link)
-			if u, err := urlpkg.Parse(u.items[0].Link); err == nil {
-				switch u.Hostname() {
-				case "t.me":
-					msg += " #tg" // Telegram
-				case "www.youtube.com":
-					msg += " #youtube" // YouTube
-				default:
-					msg += " #" + nonAlphaNumRe().ReplaceAllString(u.Hostname(), "")
-				}
-			}
-			if strings.HasPrefix(u.items[0].GUID, "https://news.ycombinator.com/item?id=") {
-				replyMarkup = &inlineKeyboard{{
-					{
-						Text: "↪ Hacker News",
-						URL:  u.items[0].GUID,
-					},
-				}}
-			}
-		}
+		return
 	}
 
 	f.slog.Debug("sending message", "feed", u.feed.url, "message", msg)
@@ -499,8 +377,187 @@ func (f *fetcher) sendUpdate(ctx context.Context, u *update) {
 	}
 
 	if err := f.send(ctx, strings.TrimSpace(msg), disableLinkPreview, replyMarkup, u.feed.messageThreadID); err != nil {
-		f.slog.Warn("failed to send message", "chat_id", f.chatID, "error", err)
+		f.slog.Warn("failed to send message",
+			slog.String("chat_id", f.chatID),
+			slog.Any("error", err),
+		)
 	}
+}
+
+func (f *fetcher) buildUpdateMessage(u *update) (msg string, replyMarkup *inlineKeyboard, err error) {
+	items, defaultTitle := f.buildFormatInput(u)
+
+	if u.feed.format != nil {
+		val, err := f.callStarlarkFormatter(u.feed.format, items)
+		if err != nil {
+			return "", nil, fmt.Errorf("formatting message: %w", err)
+		}
+		msg, replyMarkup, err = parseFormattedMessage(val)
+		if err != nil {
+			return "", nil, fmt.Errorf("parsing format result: %w", err)
+		}
+		return msg, replyMarkup, nil
+	}
+
+	msg, replyMarkup = defaultUpdateMessage(u, defaultTitle)
+	return msg, replyMarkup, nil
+}
+
+func (f *fetcher) buildFormatInput(u *update) (starlark.Value, string) {
+	if u.feed.digest {
+		list := make([]starlark.Value, 0, len(u.items))
+		for _, item := range u.items {
+			list = append(list, f.itemToStarlark(item))
+		}
+		return starlark.NewList(list), fmt.Sprintf("Updates from %s", cmp.Or(u.feed.title, u.feed.url))
+	}
+
+	item := u.items[0]
+	return f.itemToStarlark(item), cmp.Or(item.Title, item.Link)
+}
+
+func (f *fetcher) callStarlarkFormatter(format *starlark.Function, items starlark.Value) (starlark.Value, error) {
+	return starlark.Call(
+		&starlark.Thread{
+			Print: func(_ *starlark.Thread, msg string) { f.slog.Info(msg) },
+		},
+		format,
+		starlark.Tuple{items},
+		[]starlark.Tuple{},
+	)
+}
+
+func parseFormattedMessage(v starlark.Value) (msg string, replyMarkup *inlineKeyboard, err error) {
+	switch val := v.(type) {
+	case starlark.String:
+		return val.GoString(), nil, nil
+	case starlark.Tuple:
+		if len(val) == 0 {
+			return "", nil, errors.New("format tuple must include message text")
+		}
+		if len(val) > 2 {
+			return "", nil, errors.New("format tuple may contain only text and keyboard")
+		}
+
+		s, ok := val[0].(starlark.String)
+		if !ok {
+			return "", nil, fmt.Errorf("format tuple text must be a string, got %s", val[0].Type())
+		}
+		msg = s.GoString()
+
+		if len(val) == 2 {
+			replyMarkup, err = parseInlineKeyboard(val[1])
+			if err != nil {
+				return "", nil, err
+			}
+		}
+
+		return msg, replyMarkup, nil
+	default:
+		return "", nil, fmt.Errorf("format must return string or tuple, got %s", val.Type())
+	}
+}
+
+func parseInlineKeyboard(v starlark.Value) (*inlineKeyboard, error) {
+	list, ok := v.(*starlark.List)
+	if !ok {
+		return nil, fmt.Errorf("keyboard must be a list, got %s", v.Type())
+	}
+
+	rows := make([][]inlineKeyboardButton, 0, list.Len())
+	iter := list.Iterate()
+	defer iter.Done()
+
+	var rowValue starlark.Value
+	for iter.Next(&rowValue) {
+		rowList, ok := rowValue.(*starlark.List)
+		if !ok {
+			return nil, fmt.Errorf("keyboard row must be a list, got %s", rowValue.Type())
+		}
+
+		buttons := make([]inlineKeyboardButton, 0, rowList.Len())
+		rowIter := rowList.Iterate()
+		var buttonValue starlark.Value
+		for rowIter.Next(&buttonValue) {
+			buttonDict, ok := buttonValue.(*starlark.Dict)
+			if !ok {
+				return nil, fmt.Errorf("keyboard button must be a dict, got %s", buttonValue.Type())
+			}
+			button, err := parseInlineKeyboardButton(buttonDict)
+			if err != nil {
+				return nil, err
+			}
+			buttons = append(buttons, button)
+		}
+		rowIter.Done()
+
+		if len(buttons) > 0 {
+			rows = append(rows, buttons)
+		}
+	}
+
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	kb := inlineKeyboard(rows)
+	return &kb, nil
+}
+
+func parseInlineKeyboardButton(button *starlark.Dict) (inlineKeyboardButton, error) {
+	var out inlineKeyboardButton
+	for _, item := range button.Items() {
+		key, ok1 := item[0].(starlark.String)
+		val, ok2 := item[1].(starlark.String)
+		if !ok1 || !ok2 {
+			return inlineKeyboardButton{}, errors.New("keyboard button keys and values must be strings")
+		}
+
+		switch key.GoString() {
+		case "text":
+			out.Text = val.GoString()
+		case "url":
+			out.URL = val.GoString()
+		}
+	}
+
+	if out.Text == "" || out.URL == "" {
+		return inlineKeyboardButton{}, errors.New("keyboard button must include non-empty text and url")
+	}
+	return out, nil
+}
+
+func defaultUpdateMessage(u *update, defaultTitle string) (msg string, replyMarkup *inlineKeyboard) {
+	if u.feed.digest {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "<b>%s</b>\n\n", defaultTitle)
+		for _, item := range u.items {
+			fmt.Fprintf(&sb, "• <a href=%q>%s</a>\n", item.Link, cmp.Or(item.Title, item.Link))
+		}
+		return sb.String(), nil
+	}
+
+	msg = fmt.Sprintf(messageTemplate, defaultTitle, u.items[0].Link)
+	if u, err := urlpkg.Parse(u.items[0].Link); err == nil {
+		switch u.Hostname() {
+		case "t.me":
+			msg += " #tg" // Telegram
+		case "www.youtube.com":
+			msg += " #youtube" // YouTube
+		default:
+			msg += " #" + nonAlphaNumRe().ReplaceAllString(u.Hostname(), "")
+		}
+	}
+	if strings.HasPrefix(u.items[0].GUID, "https://news.ycombinator.com/item?id=") {
+		replyMarkup = &inlineKeyboard{{
+			{
+				Text: "↪ Hacker News",
+				URL:  u.items[0].GUID,
+			},
+		}}
+	}
+
+	return msg, replyMarkup
 }
 
 type message struct {

--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -316,8 +316,8 @@ func TestParseFormattedMessage(t *testing.T) {
 	t.Parallel()
 
 	t.Run("string", func(t *testing.T) {
-		msg, replyMarkup, err := parseFormattedMessage(starlark.String("hello"))
-		testutil.AssertEqual(t, err, nil)
+		msg, replyMarkup, ok := parseFormattedMessage(starlark.String("hello"))
+		testutil.AssertEqual(t, ok, true)
 		testutil.AssertEqual(t, msg, "hello")
 		testutil.AssertEqual(t, replyMarkup, (*inlineKeyboard)(nil))
 	})
@@ -332,8 +332,8 @@ func TestParseFormattedMessage(t *testing.T) {
 		dict.SetKey(starlark.String("text"), starlark.String("Open"))
 		dict.SetKey(starlark.String("url"), starlark.String("https://example.com"))
 
-		msg, replyMarkup, err := parseFormattedMessage(starlark.Tuple{starlark.String("formatted"), keyboard})
-		testutil.AssertEqual(t, err, nil)
+		msg, replyMarkup, ok := parseFormattedMessage(starlark.Tuple{starlark.String("formatted"), keyboard})
+		testutil.AssertEqual(t, ok, true)
 		testutil.AssertEqual(t, msg, "formatted")
 		if replyMarkup == nil {
 			t.Fatal("replyMarkup should not be nil")
@@ -345,33 +345,10 @@ func TestParseFormattedMessage(t *testing.T) {
 	})
 
 	t.Run("unsupported", func(t *testing.T) {
-		msg, replyMarkup, err := parseFormattedMessage(starlark.MakeInt(1))
-		if err == nil {
-			t.Fatal("expected error")
-		}
+		msg, replyMarkup, ok := parseFormattedMessage(starlark.MakeInt(1))
+		testutil.AssertEqual(t, ok, false)
 		testutil.AssertEqual(t, msg, "")
 		testutil.AssertEqual(t, replyMarkup, (*inlineKeyboard)(nil))
-	})
-
-	t.Run("tuple with invalid text", func(t *testing.T) {
-		_, _, err := parseFormattedMessage(starlark.Tuple{starlark.MakeInt(1)})
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
-
-	t.Run("tuple with invalid keyboard", func(t *testing.T) {
-		_, _, err := parseFormattedMessage(starlark.Tuple{starlark.String("msg"), starlark.String("bad")})
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
-
-	t.Run("tuple with too many elements", func(t *testing.T) {
-		_, _, err := parseFormattedMessage(starlark.Tuple{starlark.String("msg"), starlark.NewList(nil), starlark.String("x")})
-		if err == nil {
-			t.Fatal("expected error")
-		}
 	})
 }
 

--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -14,8 +14,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mmcdole/gofeed"
 	"go.astrophena.name/base/testutil"
 	"go.astrophena.name/base/txtar"
+	"go.starlark.net/starlark"
 )
 
 func TestFailingFeed(t *testing.T) {
@@ -308,4 +310,111 @@ func TestAlwaysSendNewItems(t *testing.T) {
 		t.Fatal(err)
 	}
 	testutil.AssertEqual(t, len(tm.sentMessages), 1)
+}
+
+func TestParseFormattedMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string", func(t *testing.T) {
+		msg, replyMarkup, err := parseFormattedMessage(starlark.String("hello"))
+		testutil.AssertEqual(t, err, nil)
+		testutil.AssertEqual(t, msg, "hello")
+		testutil.AssertEqual(t, replyMarkup, (*inlineKeyboard)(nil))
+	})
+
+	t.Run("tuple with keyboard", func(t *testing.T) {
+		keyboard := starlark.NewList([]starlark.Value{
+			starlark.NewList([]starlark.Value{
+				starlark.NewDict(2),
+			}),
+		})
+		dict := keyboard.Index(0).(*starlark.List).Index(0).(*starlark.Dict)
+		dict.SetKey(starlark.String("text"), starlark.String("Open"))
+		dict.SetKey(starlark.String("url"), starlark.String("https://example.com"))
+
+		msg, replyMarkup, err := parseFormattedMessage(starlark.Tuple{starlark.String("formatted"), keyboard})
+		testutil.AssertEqual(t, err, nil)
+		testutil.AssertEqual(t, msg, "formatted")
+		if replyMarkup == nil {
+			t.Fatal("replyMarkup should not be nil")
+		}
+		testutil.AssertEqual(t, len(*replyMarkup), 1)
+		testutil.AssertEqual(t, len((*replyMarkup)[0]), 1)
+		testutil.AssertEqual(t, (*replyMarkup)[0][0].Text, "Open")
+		testutil.AssertEqual(t, (*replyMarkup)[0][0].URL, "https://example.com")
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		msg, replyMarkup, err := parseFormattedMessage(starlark.MakeInt(1))
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		testutil.AssertEqual(t, msg, "")
+		testutil.AssertEqual(t, replyMarkup, (*inlineKeyboard)(nil))
+	})
+
+	t.Run("tuple with invalid text", func(t *testing.T) {
+		_, _, err := parseFormattedMessage(starlark.Tuple{starlark.MakeInt(1)})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("tuple with invalid keyboard", func(t *testing.T) {
+		_, _, err := parseFormattedMessage(starlark.Tuple{starlark.String("msg"), starlark.String("bad")})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("tuple with too many elements", func(t *testing.T) {
+		_, _, err := parseFormattedMessage(starlark.Tuple{starlark.String("msg"), starlark.NewList(nil), starlark.String("x")})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestBuildFormatInput(t *testing.T) {
+	t.Parallel()
+
+	f := &fetcher{}
+
+	t.Run("single item uses fallback title", func(t *testing.T) {
+		u := &update{
+			feed:  &feed{},
+			items: []*gofeed.Item{{Title: "", Link: "https://example.com/a"}},
+		}
+
+		_, gotTitle := f.buildFormatInput(u)
+		testutil.AssertEqual(t, gotTitle, "https://example.com/a")
+	})
+
+	t.Run("digest uses feed URL when title is empty", func(t *testing.T) {
+		u := &update{
+			feed:  &feed{digest: true, url: "https://example.com/feed.xml"},
+			items: []*gofeed.Item{{Title: "Item", Link: "https://example.com/a"}},
+		}
+
+		_, gotTitle := f.buildFormatInput(u)
+		testutil.AssertEqual(t, gotTitle, "Updates from https://example.com/feed.xml")
+	})
+}
+
+func TestDefaultUpdateMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds hacker news keyboard", func(t *testing.T) {
+		u := &update{feed: &feed{}, items: []*gofeed.Item{{
+			Title: "Title",
+			Link:  "https://example.com/post",
+			GUID:  "https://news.ycombinator.com/item?id=1",
+		}}}
+
+		_, replyMarkup := defaultUpdateMessage(u, "Title")
+		if replyMarkup == nil {
+			t.Fatal("replyMarkup should not be nil")
+		}
+		testutil.AssertEqual(t, (*replyMarkup)[0][0].Text, "↪ Hacker News")
+	})
 }


### PR DESCRIPTION
### Motivation

- Make formatter error handling explicit so malformed Starlark formatter results are surfaceable and debuggable instead of silently ignored.  
- Tighten validation of formatter return values and keyboard structure to prevent unexpected runtime panics or malformed messages.  

### Description

- Changed `buildUpdateMessage` to return an `error` instead of a boolean success flag and propagate concrete errors from formatting and parsing.  
- Made `parseFormattedMessage` return `(string, *inlineKeyboard, error)` and enforce that tuple results must have a string as the first element and at most two elements.  
- Made `parseInlineKeyboard` and `parseInlineKeyboardButton` return errors and validate that keyboard rows are lists, buttons are dicts, keys/values are strings, and each button has non-empty `text` and `url`.  
- Updated logging in `sendUpdate` to include structured `slog` attributes for feed and error details, and adjusted callers/tests accordingly.  
- Expanded unit tests in `cmd/tgfeed/fetch_test.go` to cover unsupported return types, invalid tuple text, invalid keyboard types, and tuples with too many elements.  

### Testing

- Ran `gofmt -w cmd/tgfeed/fetch.go cmd/tgfeed/fetch_test.go` to apply formatting changes.  
- Ran `go test ./cmd/tgfeed/...` and tests in the `tgfeed` package passed (`ok`).  
- Ran `go tool pre-commit`, which completed checks except `go mod tidy --diff` failed in this environment due to inability to download unrelated transitive test dependencies from `proxy.golang.org` (HTTP 403), which is unrelated to these `tgfeed` changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886a0430d08333a1b43af5ad5be081)