### PR TITLE
cmd/tgfeed: move cancellation-aware sleep helper into main and consolidate tests

### DIFF
--- a/cmd/tgfeed/fetch.go
+++ b/cmd/tgfeed/fetch.go
@@ -588,7 +588,9 @@ func (f *fetcher) send(ctx context.Context, text string, disableLinkPreview bool
 				break
 			}
 			f.slog.Warn("sending rate limited, waiting", "chat_id", f.chatID, "message", chunk, "wait", wait)
-			time.Sleep(wait)
+			if !sleep(ctx, wait) {
+				return ctx.Err()
+			}
 		}
 		if err != nil {
 			return err

--- a/cmd/tgfeed/main_test.go
+++ b/cmd/tgfeed/main_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/json"
 	"flag"
@@ -19,6 +20,7 @@ import (
 	"sync"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"go.astrophena.name/base/cli"
 	"go.astrophena.name/base/cli/clitest"
@@ -239,4 +241,32 @@ func toJSON(t *testing.T, val any) []byte {
 		t.Fatal(err)
 	}
 	return b
+}
+
+func TestSleepReturnsTrueAfterDuration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	start := time.Now()
+	if !sleep(ctx, 10*time.Millisecond) {
+		t.Fatal("sleep() = false, want true")
+	}
+	if elapsed := time.Since(start); elapsed < 10*time.Millisecond {
+		t.Fatalf("sleep() elapsed = %v, want >= %v", elapsed, 10*time.Millisecond)
+	}
+}
+
+func TestSleepReturnsFalseOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	if sleep(ctx, time.Second) {
+		t.Fatal("sleep() = true, want false")
+	}
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Fatalf("sleep() elapsed = %v, want quick return", elapsed)
+	}
 }


### PR DESCRIPTION
### Motivation
- The cancellation-aware sleep helper should live alongside the main runner to satisfy review feedback and simplify package layout.
- Retry and rate-limit waits must be cancellation-aware so shutdown and context cancellation are handled promptly.

### Description
- Moved the helper `sleep(ctx context.Context, d time.Duration) bool` into `cmd/tgfeed/main.go` and removed the standalone `sleep.go` file.
- Replaced `time.Sleep(retryIn)` in the feed retry loop with `if !sleep(ctx, retryIn) { break }` so retries stop on cancellation.
- Replaced `time.Sleep(wait)` in the sender rate-limit path with `if !sleep(ctx, wait) { return ctx.Err() }` so sending aborts on cancellation.
- Consolidated tests by moving the sleep tests into `cmd/tgfeed/main_test.go` and updated imports to include `context` and `time`, removing the separate `sleep_test.go` file.

### Testing
- Ran `go test ./cmd/tgfeed` and package tests passed.
- Ran `gofmt` formatting (`gofmt -w`) on modified files and formatting is OK.
- Ran `go tool staticcheck ./cmd/tgfeed` and it completed without issues for the package.
- Ran `go tool pre-commit` which failed in this environment due to blocked module proxy access during `go mod tidy --diff`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988809cfd208333a0d798035260bcc0)