### PR TITLE
cmd/tgfeed: refactor feed item decision flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,12 @@ If the pre-commit tool fails because `ruff` is not installed, install it with:
 $ pip install ruff
 ```
 
+## Test Style
+
+- Prefer table-driven tests using `cases := map[string]struct{ ... }{ ... }`.
+- In table test loops, use `for name, tc := range cases { ... }` and pass `name`
+  to `t.Run(name, ...)`.
+
 ## Go Style Guide
 
 In addition to standard Go idioms, follow these specific style guidelines.


### PR DESCRIPTION
Refactor the fetch item pipeline to use explicit context and typed decisions instead of passing a long list of parameters and relying on booleans.

Introduce feedItemContext to carry feed configuration, state, and per-fetch flags into item-level decision logic.

Replace feedItemDecision.process with feedItemSelection, a typed outcome with three states:
skip, mark-seen-only, and process. This makes first-run and always_send_new_items behavior explicit and easier to reason about.

Keep side effects centralized in enqueueFeedItems. decideFeedItem now computes intent only (selection + optional markSeen key), while enqueueFeedItems applies seen-item mutations and enqueues according to explicit action routing.

Update decideEnqueueAction to accept feedItemContext and keep enqueue routing consistent with the new model.

Refresh unit tests to assert typed selection outcomes and new signatures. Existing behavior remains the same, while tests now validate intent more directly.

Document the test table naming convention in AGENTS.md: use cases map and tc loop variable.

Assisted-by: Codex
