### PR TITLE
cmd/tgfeed: switch run locking to flock

### DIFF
--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -168,6 +168,8 @@ type fetcher struct {
 	state         syncx.Protected[map[string]*feedState]
 
 	stats syncx.Protected[*stats]
+
+	runLock *os.File
 }
 
 func (f *fetcher) doInit(ctx context.Context) {


### PR DESCRIPTION
### Motivation

- Replace fragile PID-probing and file-existence semantics for `.run.lock` with a robust OS-level file lock so concurrent runs are reliably detected.  
- Ensure the lock is held for the full run lifecycle by keeping the open file descriptor on the `fetcher` and releasing it on normal exit.  

### Description

- Add a `runLocker` abstraction that performs non-blocking `syscall.Flock`-based acquire/release and provides an `isLocked` probe that checks the lock primitive rather than file existence.  
- Change `acquireRunLock` to obtain a `*os.File` from `runLocker.acquire`, optionally write a human-readable payload (informational only), and store the descriptor on `fetcher.runLock`.  
- Change `releaseRunLock` to release/unlock and close the held descriptor and clear `fetcher.runLock`.  
- Change `isRunLocked` to use the new lock probe instead of `os.Stat` on the lock file.  
- Add tests: `TestRunLockerAcquireConflict` to validate acquisition conflicts and `TestRunLockLifecycle` to validate acquire/payload/isLocked/release lifecycle.  
- Update admin test to hold a real OS lock in the locked-case setup instead of pre-creating a `.run.lock` file.  

### Testing

- Ran `go test ./cmd/tgfeed` and the tgfeed package tests passed.  
- Ran `go test ./...` and all packages' tests passed.  
- Ran `go tool pre-commit` and the pre-commit checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d4a815cc83339df65c5498c87a87)