### PR TITLE
cmd/tgfeed: validate formatter tuple outputs

### DIFF
--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -720,6 +720,20 @@ func TestParseFormattedMessage(t *testing.T) {
 		testutil.AssertEqual(t, (*replyMarkup)[0][0].URL, "https://example.com")
 	})
 
+	t.Run("tuple with malformed first element", func(t *testing.T) {
+		msg, replyMarkup, ok := parseFormattedMessage(starlark.Tuple{starlark.MakeInt(1)})
+		testutil.AssertEqual(t, ok, false)
+		testutil.AssertEqual(t, msg, "")
+		testutil.AssertEqual(t, replyMarkup, (*inlineKeyboard)(nil))
+	})
+
+	t.Run("tuple with malformed keyboard", func(t *testing.T) {
+		msg, replyMarkup, ok := parseFormattedMessage(starlark.Tuple{starlark.String("formatted"), starlark.MakeInt(1)})
+		testutil.AssertEqual(t, ok, false)
+		testutil.AssertEqual(t, msg, "")
+		testutil.AssertEqual(t, replyMarkup, (*inlineKeyboard)(nil))
+	})
+
 	t.Run("unsupported", func(t *testing.T) {
 		msg, replyMarkup, ok := parseFormattedMessage(starlark.MakeInt(1))
 		testutil.AssertEqual(t, ok, false)


### PR DESCRIPTION
### Motivation

- Prevent malformed Starlark formatter outputs from producing empty/incorrect messages and make diagnosis easier when a formatter returns an unexpected shape.
- Provide structured logging with diagnostics when formatter output is invalid so operators can quickly see the value shape and why parsing failed.

### Description

- Tighten `parseFormattedMessage` to accept only a `starlark.String` or a `starlark.Tuple` whose first element is a non-empty `starlark.String`, and return `ok=false` for malformed tuples (empty tuple, non-string/empty title, or invalid keyboard payload).
- Make `buildUpdateMessage` emit a structured `slog` warning with diagnostics (`value_type`, `is_tuple`, `tuple_len`, `title_type`, `title_is_empty`, `keyboard_type`) when formatter output is invalid, implemented with helper functions `isTupleValue`, `tupleLen`, `tupleTitleType`, `tupleTitleIsEmpty`, and `tupleKeyboardType`.
- Update tests in `cmd/tgfeed/fetch_test.go` to cover the valid string path, valid tuple-with-keyboard path, and malformed cases for tuple first element and malformed keyboard value.

### Testing

- Ran `go test ./cmd/tgfeed` and the package tests passed (`ok go.astrophena.name/tools/cmd/tgfeed`).
- Ran `go tool pre-commit` and all pre-commit checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d95d13708333b079a4539ca9be52)