### PR TITLE
cmd/tgfeed: extract state persistence and run locking

### DIFF
--- a/cmd/tgfeed/admin_test.go
+++ b/cmd/tgfeed/admin_test.go
@@ -16,6 +16,7 @@ import (
 	"testing/fstest"
 
 	"go.astrophena.name/base/testutil"
+	"go.astrophena.name/tools/cmd/tgfeed/internal/state"
 )
 
 func TestAdmin(t *testing.T) {
@@ -114,12 +115,12 @@ func TestAdmin(t *testing.T) {
 	})
 	t.Run("put config (locked)", func(t *testing.T) {
 		f := setup(t, initialFS)
-		lockFile, err := (runLocker{}).acquire(filepath.Join(f.stateDir, ".run.lock"))
+		lockFile, err := state.NewLocker().Acquire(filepath.Join(f.stateDir, ".run.lock"), "")
 		if err != nil {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() {
-			if err := (runLocker{}).release(lockFile); err != nil {
+			if err := lockFile.Release(); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/cmd/tgfeed/internal/state/state.go
+++ b/cmd/tgfeed/internal/state/state.go
@@ -1,0 +1,300 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package state provides persistence and run-lock primitives used by tgfeed.
+package state
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"go.astrophena.name/base/request"
+	"go.astrophena.name/base/version"
+	"go.astrophena.name/tools/internal/atomicio"
+)
+
+type FeedState struct {
+	Disabled       bool                 `json:"disabled"`
+	LastUpdated    time.Time            `json:"last_updated"`
+	LastModified   string               `json:"last_modified,omitempty"`
+	ETag           string               `json:"etag,omitempty"`
+	ErrorCount     int                  `json:"error_count,omitempty"`
+	LastError      string               `json:"last_error,omitempty"`
+	SeenItems      map[string]time.Time `json:"seen_items,omitempty"`
+	FetchCount     int64                `json:"fetch_count"`
+	FetchFailCount int64                `json:"fetch_fail_count"`
+}
+
+func NewFeedState(now time.Time) *FeedState {
+	return &FeedState{LastUpdated: now}
+}
+
+type Snapshot struct {
+	Config        string
+	State         map[string]*FeedState
+	ErrorTemplate string
+}
+
+type Store interface {
+	LoadSnapshot(ctx context.Context) (*Snapshot, error)
+	LoadConfig(ctx context.Context) (string, error)
+	LoadState(ctx context.Context) (map[string]*FeedState, error)
+	LoadErrorTemplate(ctx context.Context) (string, error)
+	SaveConfig(ctx context.Context, config string) error
+	SaveState(ctx context.Context, state map[string]*FeedState) error
+	SaveStateJSON(ctx context.Context, content []byte) error
+	SaveErrorTemplate(ctx context.Context, content string) error
+}
+
+type Lock interface{ Release() error }
+
+type Locker interface {
+	Acquire(path string, payload string) (Lock, error)
+	IsLocked(path string) bool
+}
+
+var ErrAlreadyRunning = errors.New("already running")
+
+type Options struct {
+	StateDir             string
+	RemoteURL            string
+	HTTPClient           *http.Client
+	DefaultErrorTemplate string
+}
+
+func NewStore(opts Options) Store { return &store{opts: opts} }
+func NewLocker() Locker           { return fileLocker{} }
+
+type store struct{ opts Options }
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func (s *store) LoadSnapshot(ctx context.Context) (*Snapshot, error) {
+	config, err := s.LoadConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stateMap, err := s.LoadState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	errorTemplate, err := s.LoadErrorTemplate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &Snapshot{Config: config, State: stateMap, ErrorTemplate: errorTemplate}, nil
+}
+
+func (s *store) LoadConfig(ctx context.Context) (string, error) {
+	if s.opts.RemoteURL == "" {
+		configBytes, err := os.ReadFile(filepath.Join(s.opts.StateDir, "config.star"))
+		if err != nil {
+			return "", err
+		}
+		return string(configBytes), nil
+	}
+	b, err := s.fetch(ctx, "/api/config")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch config from remote: %w", err)
+	}
+	return string(b), nil
+}
+
+func (s *store) LoadState(ctx context.Context) (map[string]*FeedState, error) {
+	if s.opts.RemoteURL == "" {
+		stateBytes, err := os.ReadFile(filepath.Join(s.opts.StateDir, "state.json"))
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		return UnmarshalStateMap(stateBytes)
+	}
+	b, err := s.fetch(ctx, "/api/state")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch state from remote: %w", err)
+	}
+	stateMap, err := UnmarshalStateMap(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse state JSON: %w", err)
+	}
+	return stateMap, nil
+}
+
+func (s *store) LoadErrorTemplate(ctx context.Context) (string, error) {
+	if s.opts.RemoteURL == "" {
+		errorTemplateBytes, err := os.ReadFile(filepath.Join(s.opts.StateDir, "error.tmpl"))
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return "", err
+		}
+		return cmp.Or(string(errorTemplateBytes), s.opts.DefaultErrorTemplate), nil
+	}
+	b, err := s.fetch(ctx, "/api/error-template")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch error template from remote: %w", err)
+	}
+	return string(b), nil
+}
+
+func (s *store) fetch(ctx context.Context, url string) ([]byte, error) {
+	b, err := request.Make[request.Bytes](ctx, request.Params{Method: http.MethodGet, Headers: map[string]string{"User-Agent": version.UserAgent()}, URL: s.apiURL(url), HTTPClient: s.httpClient()})
+	if err != nil {
+		var statusErr *request.StatusError
+		if errors.As(err, &statusErr) {
+			var errResp *errorResponse
+			if jsonErr := json.Unmarshal(statusErr.Body, &errResp); jsonErr == nil {
+				err = errors.New(errResp.Error)
+			}
+		}
+		return nil, err
+	}
+	return b, nil
+}
+
+func (s *store) SaveState(ctx context.Context, state map[string]*FeedState) error {
+	b, err := MarshalStateMap(state)
+	if err != nil {
+		return err
+	}
+	return s.SaveStateJSON(ctx, b)
+}
+
+func (s *store) SaveStateJSON(ctx context.Context, content []byte) error {
+	if s.opts.RemoteURL == "" {
+		return atomicio.WriteFile(filepath.Join(s.opts.StateDir, "state.json"), content, 0o644)
+	}
+	_, err := request.Make[request.IgnoreResponse](ctx, request.Params{Method: http.MethodPut, URL: s.apiURL("/api/state"), Body: content, Headers: map[string]string{"Content-Type": "application/json", "User-Agent": version.UserAgent()}, WantStatusCode: http.StatusNoContent, HTTPClient: s.httpClient()})
+	if err != nil {
+		return fmt.Errorf("failed to save state to remote: %w", err)
+	}
+	return nil
+}
+
+func (s *store) SaveConfig(ctx context.Context, config string) error {
+	if s.opts.RemoteURL == "" {
+		return atomicio.WriteFile(filepath.Join(s.opts.StateDir, "config.star"), []byte(config), 0o644)
+	}
+	_, err := request.Make[request.IgnoreResponse](ctx, request.Params{Method: http.MethodPut, URL: s.apiURL("/api/config"), Body: []byte(config), Headers: map[string]string{"Content-Type": "text/plain", "User-Agent": version.UserAgent()}, WantStatusCode: http.StatusNoContent, HTTPClient: s.httpClient()})
+	if err != nil {
+		return fmt.Errorf("failed to save config to remote: %w", err)
+	}
+	return nil
+}
+
+func (s *store) SaveErrorTemplate(ctx context.Context, content string) error {
+	if s.opts.RemoteURL == "" {
+		return atomicio.WriteFile(filepath.Join(s.opts.StateDir, "error.tmpl"), []byte(content), 0o644)
+	}
+	_, err := request.Make[request.IgnoreResponse](ctx, request.Params{Method: http.MethodPut, URL: s.apiURL("/api/error-template"), Body: []byte(content), Headers: map[string]string{"Content-Type": "text/plain", "User-Agent": version.UserAgent()}, WantStatusCode: http.StatusNoContent, HTTPClient: s.httpClient()})
+	if err != nil {
+		return fmt.Errorf("failed to save error template to remote: %w", err)
+	}
+	return nil
+}
+
+func MarshalStateMap(stateMap map[string]*FeedState) ([]byte, error) {
+	return json.MarshalIndent(stateMap, "", "  ")
+}
+
+func UnmarshalStateMap(b []byte) (map[string]*FeedState, error) {
+	stateMap := make(map[string]*FeedState)
+	if len(b) == 0 {
+		return stateMap, nil
+	}
+	if err := json.Unmarshal(b, &stateMap); err != nil {
+		return nil, err
+	}
+	return stateMap, nil
+}
+
+func (s *store) httpClient() *http.Client {
+	if strings.HasPrefix(s.opts.RemoteURL, "/") {
+		return &http.Client{Transport: &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", s.opts.RemoteURL)
+		}}}
+	}
+	return s.opts.HTTPClient
+}
+
+func (s *store) apiURL(endpoint string) string {
+	if strings.HasPrefix(s.opts.RemoteURL, "/") {
+		return "http://unix" + endpoint
+	}
+	return s.opts.RemoteURL + endpoint
+}
+
+type fileLock struct{ file *os.File }
+
+func (l *fileLock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	if err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN); err != nil {
+		if closeErr := l.file.Close(); closeErr != nil {
+			return errors.Join(err, closeErr)
+		}
+		return err
+	}
+	return l.file.Close()
+}
+
+type fileLocker struct{}
+
+func (fileLocker) Acquire(path string, payload string) (Lock, error) {
+	lockFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if closeErr := lockFile.Close(); closeErr != nil {
+			return nil, errors.Join(err, closeErr)
+		}
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, ErrAlreadyRunning
+		}
+		return nil, err
+	}
+	if payload != "" {
+		if err := lockFile.Truncate(0); err != nil {
+			_ = (&fileLock{file: lockFile}).Release()
+			return nil, err
+		}
+		if _, err := lockFile.Seek(0, 0); err != nil {
+			_ = (&fileLock{file: lockFile}).Release()
+			return nil, err
+		}
+		if _, err := lockFile.WriteString(payload); err != nil {
+			_ = (&fileLock{file: lockFile}).Release()
+			return nil, err
+		}
+	}
+	return &fileLock{file: lockFile}, nil
+}
+
+func (fileLocker) IsLocked(path string) bool {
+	lockFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return false
+	}
+	defer lockFile.Close()
+
+	err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		return false
+	}
+
+	return errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)
+}

--- a/cmd/tgfeed/internal/state/state_test.go
+++ b/cmd/tgfeed/internal/state/state_test.go
@@ -1,0 +1,84 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package state
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.astrophena.name/base/testutil"
+)
+
+func TestStoreLoadSnapshotLocalFallbackTemplate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.star"), []byte("feed(url=\"https://example.com\")"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(Options{StateDir: dir, DefaultErrorTemplate: "default template"})
+	snapshot, err := store.LoadSnapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.AssertEqual(t, snapshot.ErrorTemplate, "default template")
+	testutil.AssertEqual(t, len(snapshot.State), 0)
+}
+
+func TestStateMapRoundtrip(t *testing.T) {
+	t.Parallel()
+	input := map[string]*FeedState{"https://example.com": {LastUpdated: time.Date(2026, time.January, 1, 1, 2, 3, 0, time.UTC), ErrorCount: 2}}
+	b, err := MarshalStateMap(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := UnmarshalStateMap(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.AssertEqual(t, got, input)
+}
+
+func TestStoreRemoteErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/config" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"bad config"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	store := NewStore(Options{RemoteURL: srv.URL, HTTPClient: srv.Client()})
+	_, err := store.LoadSnapshot(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "bad config") {
+		t.Fatalf("expected propagated remote error, got %v", err)
+	}
+}
+
+func TestLockerConflict(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), ".run.lock")
+	locker := NewLocker()
+	first, err := locker.Acquire(path, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Release()
+	_, err = locker.Acquire(path, "")
+	if err == nil {
+		t.Fatal("expected lock conflict")
+	}
+	testutil.AssertEqual(t, err == ErrAlreadyRunning, true)
+}


### PR DESCRIPTION
### Motivation
- Isolate all state responsibilities (config, runtime state, error template, and run locking) behind a dedicated module so the command layer depends on stable interfaces instead of direct filesystem/remote logic.
- Prepare the codebase for the next refactor phase by encapsulating persistence and locking with minimal behavioral changes to existing commands.

### Description
- Added a new package `cmd/tgfeed/internal/state` providing `Store` and `Locker` abstractions and a local file-backed implementation plus remote admin-API adapters, with helpers `MarshalStateMap`/`UnmarshalStateMap`.
- Refactored `fetcher` to use `state.Store` and `state.Locker` instead of performing raw file or HTTP admin I/O and to hold `state.Lock` instead of a raw `*os.File` run lock.
- Updated admin handlers to route config/state/error-template reads and writes through the `Store` interface while preserving existing validation and endpoint semantics.
- Added conversion helpers between the command-local `feedState` model and the `state.FeedState` model to avoid changing runtime logic, and updated tests to use the new API where appropriate.

### Testing
- Ran `go test ./cmd/tgfeed/...` and all tgfeed package tests and new `internal/state` tests passed.
- Ran `go tool pre-commit` and all formatting/static checks passed.
- Added focused unit tests in `cmd/tgfeed/internal/state` covering load/save roundtrips, default template fallback, remote error propagation, and lock conflict behavior, and adjusted existing admin/state tests to validate the extracted abstractions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a38d87df0833386ac50e759c30482)