### PR TITLE
cmd/tgfeed: refine state integration and document internals

### DIFF
--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -140,7 +140,7 @@ func TestBlockAndKeepRules(t *testing.T) {
 
 		config := readFile(t, match)
 
-		state := map[string]*feedState{
+		state := map[string]*state.Feed{
 			"https://example.com/feed.xml": {
 				LastUpdated: time.Time{},
 			},
@@ -179,7 +179,7 @@ func TestDigestAndFormat(t *testing.T) {
 		config := readFile(t, match)
 
 		// Create a mock state where the feed is new (LastUpdated zero).
-		state := map[string]*feedState{
+		state := map[string]*state.Feed{
 			"https://example.com/feed.xml": {
 				LastUpdated: time.Time{},
 			},
@@ -223,7 +223,7 @@ func TestAlwaysSendNewItems(t *testing.T) {
 
 	config := readFile(t, "testdata/new_items/config.star")
 
-	state := map[string]*feedState{}
+	state := map[string]*state.Feed{}
 	ar := &txtar.Archive{
 		Files: []txtar.File{
 			{Name: "config.star", Data: config},
@@ -339,7 +339,7 @@ func TestDecideFeedItem(t *testing.T) {
 
 	cases := map[string]struct {
 		fd            *feed
-		state         *feedState
+		state         *state.Feed
 		item          *gofeed.Item
 		exists        bool
 		justEnabled   bool
@@ -350,7 +350,7 @@ func TestDecideFeedItem(t *testing.T) {
 			fd: &feed{
 				alwaysSendNewItems: true,
 			},
-			state: &feedState{SeenItems: map[string]time.Time{}},
+			state: &state.Feed{SeenItems: map[string]time.Time{}},
 			item: &gofeed.Item{
 				GUID:            "old",
 				Link:            "https://example.com/old",
@@ -365,7 +365,7 @@ func TestDecideFeedItem(t *testing.T) {
 			fd: &feed{
 				alwaysSendNewItems: true,
 			},
-			state: &feedState{SeenItems: map[string]time.Time{}},
+			state: &state.Feed{SeenItems: map[string]time.Time{}},
 			item: &gofeed.Item{
 				GUID:            "new",
 				Link:            "https://example.com/new",
@@ -380,7 +380,7 @@ func TestDecideFeedItem(t *testing.T) {
 			fd: &feed{
 				alwaysSendNewItems: true,
 			},
-			state: &feedState{SeenItems: map[string]time.Time{}},
+			state: &state.Feed{SeenItems: map[string]time.Time{}},
 			item: &gofeed.Item{
 				GUID:            "first",
 				Link:            "https://example.com/first",
@@ -395,7 +395,7 @@ func TestDecideFeedItem(t *testing.T) {
 			fd: &feed{
 				alwaysSendNewItems: true,
 			},
-			state: &feedState{SeenItems: map[string]time.Time{
+			state: &state.Feed{SeenItems: map[string]time.Time{
 				"seen": now,
 			}},
 			item: &gofeed.Item{
@@ -410,7 +410,7 @@ func TestDecideFeedItem(t *testing.T) {
 		},
 		"published before last update is ignored in regular mode": {
 			fd: &feed{},
-			state: &feedState{
+			state: &state.Feed{
 				LastUpdated: now,
 			},
 			item: &gofeed.Item{
@@ -425,7 +425,7 @@ func TestDecideFeedItem(t *testing.T) {
 		},
 		"nil published timestamp is accepted in regular mode": {
 			fd: &feed{},
-			state: &feedState{
+			state: &state.Feed{
 				LastUpdated: now,
 			},
 			item: &gofeed.Item{
@@ -525,7 +525,7 @@ func TestHandleFeedStatus(t *testing.T) {
 		reqURL                 string
 		statusCode             int
 		body                   string
-		initialState           feedState
+		initialState           state.Feed
 		wantHandled            bool
 		wantRetry              bool
 		wantRetryIn            time.Duration
@@ -538,7 +538,7 @@ func TestHandleFeedStatus(t *testing.T) {
 		"not modified": {
 			reqURL:     "https://example.com/feed.xml",
 			statusCode: http.StatusNotModified,
-			initialState: feedState{
+			initialState: state.Feed{
 				ErrorCount: 3,
 				LastError:  "oops",
 			},

--- a/cmd/tgfeed/internal/state/feed.go
+++ b/cmd/tgfeed/internal/state/feed.go
@@ -4,6 +4,8 @@
 
 package state
 
+import "maps"
+
 import "time"
 
 // Clone returns a deep copy of feed state.
@@ -14,9 +16,7 @@ func (f *Feed) Clone() *Feed {
 	cp := *f
 	if f.SeenItems != nil {
 		cp.SeenItems = make(map[string]time.Time, len(f.SeenItems))
-		for k, v := range f.SeenItems {
-			cp.SeenItems[k] = v
-		}
+		maps.Copy(cp.SeenItems, f.SeenItems)
 	}
 	return &cp
 }

--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -225,7 +225,7 @@ func (f *fetcher) listFeeds(ctx context.Context, w io.Writer) error {
 	var sb strings.Builder
 
 	for _, feed := range f.feeds {
-		state, hasState := f.getState(feed.url)
+		state, hasState := f.state.Get(feed.url)
 		fmt.Fprintf(&sb, "%s", feed.url)
 		if !hasState {
 			fmt.Fprintf(&sb, " \n")
@@ -325,7 +325,7 @@ func (f *fetcher) edit(ctx context.Context) error {
 		break
 	}
 
-	return f.saveConfig(ctx)
+	return f.store.SaveConfig(ctx, f.config)
 }
 
 // ask prompts the user for a yes or no answer.
@@ -489,7 +489,7 @@ func (f *fetcher) reenable(ctx context.Context, url string) error {
 		return err
 	}
 
-	_, ok := f.getState(url)
+	_, ok := f.state.Get(url)
 	if !ok {
 		return fmt.Errorf("%q: %w", url, errNoFeed)
 	}

--- a/cmd/tgfeed/main_test.go
+++ b/cmd/tgfeed/main_test.go
@@ -86,7 +86,7 @@ func TestFetcherMain(t *testing.T) {
 			Args:               []string{"reenable", "https://example.com/disabled.xml"},
 			WantNothingPrinted: true,
 			CheckFunc: func(t *testing.T, f *fetcher) {
-				st, ok := f.getState("https://example.com/disabled.xml")
+				st, ok := f.state.Get("https://example.com/disabled.xml")
 				testutil.AssertEqual(t, ok, true)
 				testutil.AssertEqual(t, st.Disabled, false)
 			},

--- a/cmd/tgfeed/state.go
+++ b/cmd/tgfeed/state.go
@@ -13,15 +13,14 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/mmcdole/gofeed"
 	"go.astrophena.name/tools/cmd/tgfeed/internal/format"
 	"go.astrophena.name/tools/cmd/tgfeed/internal/state"
 	"go.astrophena.name/tools/internal/filelock"
 	"go.astrophena.name/tools/internal/starlark/interpreter"
+
+	"github.com/mmcdole/gofeed"
 	"go.starlark.net/starlark"
 )
-
-type feedState = state.Feed
 
 // Feed state.
 
@@ -57,10 +56,6 @@ func newFeedBuiltin(feeds *[]*feed) *starlark.Builtin {
 		*feeds = append(*feeds, f)
 		return starlark.None, nil
 	})
-}
-
-func (f *fetcher) getState(url string) (fdState *state.Feed, exists bool) {
-	return f.state.Get(url)
 }
 
 func (f *fetcher) withFeedState(ctx context.Context, url string, fn func(*state.Feed, bool) bool) error {
@@ -169,10 +164,6 @@ func (f *fetcher) validateFeedFormat(fd *feed) error {
 	}
 
 	return nil
-}
-
-func (f *fetcher) saveConfig(ctx context.Context) error {
-	return f.store.SaveConfig(ctx, f.config)
 }
 
 func (f *fetcher) acquireRunLock() error {


### PR DESCRIPTION
Replace local state alias usage with state.Feed across tgfeed code paths and tests, and simplify call sites by using FeedSet.Get and Store.SaveConfig directly. Remove redundant fetcher helper wrappers now that the state surface is used consistently.

Improve implementation details by using maps.Copy for cloning seen-items state and strings.Builder for digest fallback message assembly.

Expand package and API documentation for cmd/tgfeed/internal/state and cmd/tgfeed/internal/format, including usage-oriented package comments and clearer exported type and function docs with Go doc links.

Assisted-by: Codex (GPT-5)
