### PR TITLE
cmd/tgfeed: improve feed fetching error handling

### DIFF
--- a/cmd/tgfeed/fetch.go
+++ b/cmd/tgfeed/fetch.go
@@ -164,6 +164,10 @@ func (f *fetcher) fetch(ctx context.Context, fd *feed, updates chan *update) (re
 
 	res, err := f.makeFeedRequest(req)
 	if err != nil {
+		if isTransientError(err) {
+			f.slog.Warn("transient network error, retrying", "feed", fd.url, "error", err)
+			return true, 5 * time.Second
+		}
 		f.handleFetchFailure(ctx, fd.url, err)
 		return false, 0
 	}
@@ -276,10 +280,46 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 		}
 	}
 
+	// Handle standard HTTP Retry-After for Too Many Requests and Service Unavailable.
+	if res.StatusCode == http.StatusTooManyRequests || res.StatusCode == http.StatusServiceUnavailable {
+		if t, found := retry.RetryAfter(res.Header.Get("Retry-After")); found {
+			// Limit backoff to a reasonable maximum (context deadline or 5 minutes),
+			// as Retry-After could be hours or days which would block the goroutine.
+			const maxRetryAfter = 5 * time.Minute
+			if t <= maxRetryAfter {
+				f.slog.Warn("rate-limited (Retry-After)", "feed", fd.url, "retry_in", t)
+				return feedStatusResult{
+					handled: true,
+					retry:   true,
+					retryIn: t,
+					class:   res.StatusCode / 100,
+				}, nil
+			}
+			f.slog.Warn("rate-limited (Retry-After), but wait time is too long", "feed", fd.url, "retry_in", t, "max_retry_in", maxRetryAfter)
+		}
+	}
+
+	// Retry on generic 5xx server errors without Retry-After header.
+	if res.StatusCode >= 500 && res.StatusCode < 600 {
+		return feedStatusResult{
+			handled: true,
+			retry:   true,
+			retryIn: 5 * time.Second,
+			class:   res.StatusCode / 100,
+		}, nil
+	}
+
 	return feedStatusResult{
 		handled: true,
 		class:   res.StatusCode / 100,
 	}, fmt.Errorf("want 200, got %d: %s", res.StatusCode, body)
+}
+
+func isTransientError(err error) bool {
+	if netErr, ok := errors.AsType[net.Error](err); ok {
+		return netErr.Timeout() || strings.Contains(err.Error(), "connection reset by peer")
+	}
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
 
 func readFeedErrorBody(r io.Reader) (body []byte, hasBody bool) {
@@ -494,6 +534,14 @@ func (f *fetcher) handleFetchFailure(ctx context.Context, url string, err error)
 
 		if err := f.errNotify(ctx, err); err != nil {
 			f.slog.Warn("failed to send error notification", "error", err)
+		} else {
+			// Successfully notified, clear the pending flag.
+			if updateErr := f.withFeedState(ctx, url, func(state *state.Feed, _ bool) bool {
+				state.DisabledNotifyPending = false
+				return true
+			}); updateErr != nil {
+				f.slog.Warn("failed to persist feed failure state (DisabledNotifyPending)", "feed", url, "error", updateErr)
+			}
 		}
 	}
 }

--- a/cmd/tgfeed/internal/retry/retry.go
+++ b/cmd/tgfeed/internal/retry/retry.go
@@ -24,6 +24,29 @@ func Retryable(host string, body []byte) (time.Duration, bool) {
 	return f(body)
 }
 
+// RetryAfter parses the standard HTTP Retry-After header and returns the duration
+// to wait before retrying, and a boolean indicating whether the header was valid.
+func RetryAfter(header string) (time.Duration, bool) {
+	if header == "" {
+		return 0, false
+	}
+
+	// Try parsing as delay-seconds.
+	if delay, err := strconv.Atoi(header); err == nil && delay >= 0 {
+		return time.Duration(delay) * time.Second, true
+	}
+
+	// Try parsing as HTTP-date.
+	if t, err := time.Parse(time.RFC1123, header); err == nil {
+		if d := time.Until(t); d >= 0 {
+			return d, true
+		}
+		return 0, true // Past date means retry immediately.
+	}
+
+	return 0, false
+}
+
 var handlers = map[string]func([]byte) (time.Duration, bool){
 	"tg.i-c-a.su": func(body []byte) (time.Duration, bool) {
 		var response struct {

--- a/cmd/tgfeed/internal/retry/retry_test.go
+++ b/cmd/tgfeed/internal/retry/retry_test.go
@@ -60,3 +60,63 @@ func TestTelegramRSSBridge(t *testing.T) {
 		})
 	}
 }
+
+func TestRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		header string
+		want   time.Duration
+		found  bool
+	}{
+		"empty": {
+			header: "",
+			want:   0,
+			found:  false,
+		},
+		"delay-seconds": {
+			header: "120",
+			want:   120 * time.Second,
+			found:  true,
+		},
+		"invalid delay-seconds": {
+			header: "-5",
+			want:   0,
+			found:  false,
+		},
+		"http-date future": {
+			header: time.Now().Add(5 * time.Minute).Format(time.RFC1123),
+			want:   5 * time.Minute,
+			found:  true, // exact duration might be slightly less, handled below
+		},
+		"http-date past": {
+			header: time.Now().Add(-5 * time.Minute).Format(time.RFC1123),
+			want:   0,
+			found:  true,
+		},
+		"invalid format": {
+			header: "not a date or number",
+			want:   0,
+			found:  false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, found := RetryAfter(tc.header)
+			testutil.AssertEqual(t, found, tc.found)
+			// For future dates, allow a small time drift delta.
+			if tc.found && tc.want > 0 {
+				diff := got - tc.want
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff > time.Second {
+					t.Errorf("RetryAfter(%q) duration = %v; want ~%v", tc.header, got, tc.want)
+				}
+			} else {
+				testutil.AssertEqual(t, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/tgfeed/internal/state/feed.go
+++ b/cmd/tgfeed/internal/state/feed.go
@@ -60,6 +60,7 @@ func (f *Feed) MarkFetchFailure(err error, threshold int) (disabled bool) {
 	f.LastError = err.Error()
 	if threshold > 0 && f.ErrorCount >= threshold && !f.Disabled {
 		f.Disabled = true
+		f.DisabledNotifyPending = true
 		return true
 	}
 	return false
@@ -68,6 +69,7 @@ func (f *Feed) MarkFetchFailure(err error, threshold int) (disabled bool) {
 // Reenable clears failure markers and enables future fetching.
 func (f *Feed) Reenable() {
 	f.Disabled = false
+	f.DisabledNotifyPending = false
 	f.ErrorCount = 0
 	f.LastError = ""
 }

--- a/cmd/tgfeed/internal/state/state.go
+++ b/cmd/tgfeed/internal/state/state.go
@@ -46,15 +46,16 @@ import (
 // The concrete JSON representation is intentionally private to this package.
 // Callers should mutate feed state via methods rather than raw field access.
 type Feed struct {
-	Disabled       bool                 `json:"disabled"`
-	LastUpdated    time.Time            `json:"last_updated"`
-	LastModified   string               `json:"last_modified,omitempty"`
-	ETag           string               `json:"etag,omitempty"`
-	ErrorCount     int                  `json:"error_count,omitempty"`
-	LastError      string               `json:"last_error,omitempty"`
-	SeenItems      map[string]time.Time `json:"seen_items,omitempty"`
-	FetchCount     int64                `json:"fetch_count"`
-	FetchFailCount int64                `json:"fetch_fail_count"`
+	Disabled              bool                 `json:"disabled"`
+	DisabledNotifyPending bool                 `json:"disabled_notify_pending,omitempty"`
+	LastUpdated           time.Time            `json:"last_updated"`
+	LastModified          string               `json:"last_modified,omitempty"`
+	ETag                  string               `json:"etag,omitempty"`
+	ErrorCount            int                  `json:"error_count,omitempty"`
+	LastError             string               `json:"last_error,omitempty"`
+	SeenItems             map[string]time.Time `json:"seen_items,omitempty"`
+	FetchCount            int64                `json:"fetch_count"`
+	FetchFailCount        int64                `json:"fetch_fail_count"`
 }
 
 // NewFeed initializes a feed state record with a non-zero LastUpdated value.

--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -411,6 +411,24 @@ func (f *fetcher) run(ctx context.Context) error {
 
 	var fetchedFeeds atomic.Int64
 
+	// Send pending notifications for feeds that failed and were disabled,
+	// but the notification failed to send.
+	for _, feed := range f.feeds {
+		if fdState, ok := f.state.Get(feed.url); ok && fdState.DisabledNotifyPending {
+			err := fmt.Errorf("fetching feed %q failed after %d previous attempts: feed was disabled, to reenable it run 'tgfeed reenable %q'", feed.url, fdState.ErrorCount, feed.url)
+			if nErr := f.errNotify(ctx, err); nErr != nil {
+				f.slog.Warn("failed to send pending error notification", "feed", feed.url, "error", nErr)
+			} else {
+				if updateErr := f.withFeedState(ctx, feed.url, func(state *state.Feed, _ bool) bool {
+					state.DisabledNotifyPending = false
+					return true
+				}); updateErr != nil {
+					f.slog.Warn("failed to persist feed failure state (DisabledNotifyPending)", "feed", feed.url, "error", updateErr)
+				}
+			}
+		}
+	}
+
 	// Enqueue fetches.
 	fetchWg := syncx.NewLimitedWaitGroup(fetchConcurrencyLimit)
 	for _, feed := range shuffle(f.feeds) {
@@ -522,7 +540,7 @@ func (f *fetcher) run(ctx context.Context) error {
 	}
 
 	f.stats.ReadAccess(func(s *stats) {
-		if err := f.putStats(ctx, s); err != nil {
+		if err := f.putStats(s); err != nil {
 			f.slog.Warn("failed to upload stats", "error", err)
 		}
 	})

--- a/cmd/tgfeed/stats.go
+++ b/cmd/tgfeed/stats.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"math"
 	"os"
@@ -149,7 +148,7 @@ func topFeedStats(input map[string]*feedStats, less func(a *feedStats, b *feedSt
 	return result
 }
 
-func (f *fetcher) putStats(ctx context.Context, s *stats) error {
+func (f *fetcher) putStats(s *stats) error {
 	statsDir := filepath.Join(f.stateDir, "stats")
 	if err := os.MkdirAll(statsDir, 0o755); err != nil {
 		return err

--- a/cmd/tgfeed/stats_test.go
+++ b/cmd/tgfeed/stats_test.go
@@ -34,7 +34,7 @@ func TestPutStats(t *testing.T) {
 		MemoryUsage:      9,
 	}
 
-	if err := f.putStats(t.Context(), s); err != nil {
+	if err := f.putStats(s); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
- Handle HTTP Retry-After header for 429 and 503 responses.

- Add intra-run retries for transient network errors (timeouts, reset, etc.) and generic 500-level errors.

- Fix potential loss of feed disable notifications by introducing DisabledNotifyPending and recovering failed deliveries on next fetch.

Assisted-by: Antigravity
