### PR TITLE
cmd/tgfeed: add sample enclosures to config validation

### DIFF
--- a/cmd/tgfeed/state.go
+++ b/cmd/tgfeed/state.go
@@ -147,9 +147,16 @@ func (f *fetcher) validateFeedFormat(fd *feed) error {
 		Items: []*gofeed.Item{{
 			Title:       "Sample title",
 			Description: "Sample description",
-			Link:        "https://example.com/item",
-			GUID:        "sample-guid",
-			Published:   time.Now().Format(time.RFC3339),
+			Content:     "Sample content",
+			Categories:  []string{"Sample category"},
+			Enclosures: []*gofeed.Enclosure{{
+				URL:    "https://example.com/item.jpg",
+				Type:   "image/jpeg",
+				Length: "123",
+			}},
+			Link:      "https://example.com/item",
+			GUID:      "sample-guid",
+			Published: time.Now().Format(time.RFC3339),
 		}},
 	}
 	items, _ := format.BuildFormatInput(update)


### PR DESCRIPTION
This commit updates `validateFeedFormat` in `cmd/tgfeed/state.go` to inject sample data into these fields on the dummy item. Consequently, format functions that process these fields will execute on the dummy data during configuration validation, and errors will be reported at startup rather than failing unpredictably when actual items are processed.

---
*PR created automatically by Jules for task [6501986313826532654](https://jules.google.com/task/6501986313826532654) started by @astrophena*