### PR TITLE
cmd/tgfeed/internal/ghnotify: fix PR link replacement

### DIFF
--- a/cmd/tgfeed/internal/ghnotify/ghnotify.go
+++ b/cmd/tgfeed/internal/ghnotify/ghnotify.go
@@ -267,7 +267,7 @@ func rewriteURL(url string) string {
 		return ""
 	}
 	url = strings.ReplaceAll(url, "https://api.github.com/repos/", "https://github.com/")
-	url = strings.ReplaceAll(url, "pulls", "pull") // fix PR links
+	url = strings.ReplaceAll(url, "/pulls/", "/pull/") // fix PR links
 	return url
 }
 

--- a/cmd/tgfeed/internal/ghnotify/ghnotify_test.go
+++ b/cmd/tgfeed/internal/ghnotify/ghnotify_test.go
@@ -71,9 +71,10 @@ func TestHandler(t *testing.T) {
 
 func TestRewriteURL(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/actions":                              "https://github.com/actions",
-		"https://api.github.com/repos/astrophena/tools/pulls/10":  "https://github.com/astrophena/tools/pull/10",
-		"https://api.github.com/repos/astrophena/tools/issues/10": "https://github.com/astrophena/tools/issues/10",
+		"https://github.com/actions":                                 "https://github.com/actions",
+		"https://api.github.com/repos/astrophena/tools/pulls/10":     "https://github.com/astrophena/tools/pull/10",
+		"https://api.github.com/repos/astrophena/tools/issues/10":    "https://github.com/astrophena/tools/issues/10",
+		"https://api.github.com/repos/astrophena/pulls-repo/pulls/1": "https://github.com/astrophena/pulls-repo/pull/1",
 	}
 
 	for got, want := range cases {


### PR DESCRIPTION
Improved the `rewriteURL` function in `cmd/tgfeed/internal/ghnotify/ghnotify.go` to avoid accidental replacements of the string "pulls" when it appears in repository or owner names. The logic now specifically replaces "/pulls/" with "/pull/". Added a regression test case in `cmd/tgfeed/internal/ghnotify/ghnotify_test.go` to ensure correctness.

---
*PR created automatically by Jules for task [14485962000204195395](https://jules.google.com/task/14485962000204195395) started by @astrophena*