### PR TITLE
cmd/tgfeed/internal/ghnotify: fix PR links more robustly

### DIFF
--- a/cmd/tgfeed/internal/ghnotify/ghnotify.go
+++ b/cmd/tgfeed/internal/ghnotify/ghnotify.go
@@ -267,7 +267,11 @@ func rewriteURL(url string) string {
 		return ""
 	}
 	url = strings.ReplaceAll(url, "https://api.github.com/repos/", "https://github.com/")
-	url = strings.ReplaceAll(url, "/pulls/", "/pull/") // fix PR links
+	// Fix PR links. Replace only the last occurrence of /pulls/ to avoid
+	// misidentifying repositories named "pulls".
+	if i := strings.LastIndex(url, "/pulls/"); i != -1 {
+		url = url[:i] + "/pull/" + url[i+len("/pulls/"):]
+	}
 	return url
 }
 

--- a/cmd/tgfeed/internal/ghnotify/ghnotify_test.go
+++ b/cmd/tgfeed/internal/ghnotify/ghnotify_test.go
@@ -75,6 +75,7 @@ func TestRewriteURL(t *testing.T) {
 		"https://api.github.com/repos/astrophena/tools/pulls/10":     "https://github.com/astrophena/tools/pull/10",
 		"https://api.github.com/repos/astrophena/tools/issues/10":    "https://github.com/astrophena/tools/issues/10",
 		"https://api.github.com/repos/astrophena/pulls-repo/pulls/1": "https://github.com/astrophena/pulls-repo/pull/1",
+		"https://api.github.com/repos/astrophena/pulls/pulls/1":      "https://github.com/astrophena/pulls/pull/1",
 	}
 
 	for got, want := range cases {


### PR DESCRIPTION
Improved the robustness of URL rewriting for GitHub PR notifications by only replacing the final occurrence of "/pulls/" with "/pull/". Added a test case to verify that repository names containing "pulls" are handled correctly.

---
*PR created automatically by Jules for task [6619743477105374153](https://jules.google.com/task/6619743477105374153) started by @astrophena*