### PR TITLE
internal/starlark/go2star: improve canBeInt boundary checks and tests

### DIFF
--- a/internal/starlark/go2star/go2star.go
+++ b/internal/starlark/go2star/go2star.go
@@ -121,8 +121,18 @@ func structToDict(val reflect.Value) (starlark.Value, error) {
 // canBeInt reports if the float can be converted to int without losing
 // precision.
 func canBeInt(f float64) bool {
-	// Check if the float is within the representable range of int.
-	if f < math.MinInt || f > math.MaxInt {
+	// Check if the float is within the representable range of int64.
+	//
+	// math.MaxInt64 (2^63 - 1) is not exactly representable as float64 and is
+	// rounded to the next power of 2 (2^63). Therefore, the simple check
+	// f > math.MaxInt64 would return false for f = 2^63, which would then
+	// overflow during conversion to int64.
+	//
+	// math.MinInt64 (-2^63) is exactly representable as float64. We use its
+	// absolute value as the exclusive upper bound, which is also exactly
+	// representable and provides the correct limit for int64 across all
+	// architectures.
+	if f < float64(math.MinInt64) || f >= -float64(math.MinInt64) {
 		return false
 	}
 	// Check if the float has a fractional part (i.e., it's not a whole number).

--- a/internal/starlark/go2star/go2star_test.go
+++ b/internal/starlark/go2star/go2star_test.go
@@ -5,9 +5,7 @@
 package go2star
 
 import (
-	"fmt"
 	"math"
-	"reflect"
 	"testing"
 	"time"
 
@@ -21,37 +19,45 @@ type (
 )
 
 func TestToValue(t *testing.T) {
-	cases := []struct {
+	cases := map[string]struct {
 		in   any
 		want starlark.Value
 	}{
 		// Basic types.
-		{nil, starlark.None},
-		{true, starlark.True},
-		{false, starlark.False},
-		{"hello", starlark.String("hello")},
-		{123, starlark.MakeInt(123)},
-		{int8(42), starlark.MakeInt(42)},
-		{int16(-1000), starlark.MakeInt(-1000)},
-		{uint(123), starlark.MakeUint(123)},
-		{uint8(255), starlark.MakeUint(255)},
-		{uint16(65535), starlark.MakeUint(65535)},
-		{int32(math.MaxInt32), starlark.MakeInt(math.MaxInt32)},
-		{3.1415, starlark.Float(3.1415)},
+		"nil":    {nil, starlark.None},
+		"true":   {true, starlark.True},
+		"false":  {false, starlark.False},
+		"string": {"hello", starlark.String("hello")},
+		"int":    {123, starlark.MakeInt(123)},
+		"int8":   {int8(42), starlark.MakeInt(42)},
+		"int16":  {int16(-1000), starlark.MakeInt(-1000)},
+		"uint":   {uint(123), starlark.MakeUint(123)},
+		"uint8":  {uint8(255), starlark.MakeUint(255)},
+		"uint16": {uint16(65535), starlark.MakeUint(65535)},
+		"int32":  {int32(math.MaxInt32), starlark.MakeInt(math.MaxInt32)},
+		"float":  {3.1415, starlark.Float(3.1415)},
 
 		// Floats that can be represented as ints.
-		{10.0, starlark.MakeInt(10)},
-		{float32(-5.0), starlark.MakeInt(-5)},
+		"float10.0":   {10.0, starlark.MakeInt(10)},
+		"float32-5.0": {float32(-5.0), starlark.MakeInt(-5)},
+
+		// Boundary float values.
+		"math.MaxInt64 as float":  {float64(math.MaxInt64), starlark.Float(float64(math.MaxInt64))},
+		"math.MinInt64 as float":  {float64(math.MinInt64), starlark.MakeInt64(math.MinInt64)},
+		"-math.MinInt64 as float": {-float64(math.MinInt64), starlark.Float(-float64(math.MinInt64))},
+		"math.NaN":                {math.NaN(), starlark.Float(math.NaN())},
+		"math.Inf(1)":             {math.Inf(1), starlark.Float(math.Inf(1))},
+		"math.Inf(-1)":            {math.Inf(-1), starlark.Float(math.Inf(-1))},
 
 		// Time.
-		{time.Date(2023, 8, 15, 14, 30, 0, 0, time.UTC), starlarktime.Time(time.Date(2023, 8, 15, 14, 30, 0, 0, time.UTC))},
+		"time.Time": {time.Date(2023, 8, 15, 14, 30, 0, 0, time.UTC), starlarktime.Time(time.Date(2023, 8, 15, 14, 30, 0, 0, time.UTC))},
 
 		// Slices.
-		{[]int{1, 2, 3}, starlark.NewList([]starlark.Value{starlark.MakeInt(1), starlark.MakeInt(2), starlark.MakeInt(3)})},
-		{[]string{"a", "b"}, starlark.NewList([]starlark.Value{starlark.String("a"), starlark.String("b")})},
+		"slice_int":    {[]int{1, 2, 3}, starlark.NewList([]starlark.Value{starlark.MakeInt(1), starlark.MakeInt(2), starlark.MakeInt(3)})},
+		"slice_string": {[]string{"a", "b"}, starlark.NewList([]starlark.Value{starlark.String("a"), starlark.String("b")})},
 
 		// Maps.
-		{
+		"map": {
 			map[string]int{"one": 1},
 			func() starlark.Value {
 				dict := starlark.NewDict(1)
@@ -61,7 +67,7 @@ func TestToValue(t *testing.T) {
 		},
 
 		// Structs.
-		{
+		"struct": {
 			struct {
 				Name string
 				Age  int
@@ -73,7 +79,7 @@ func TestToValue(t *testing.T) {
 				return dict
 			}(),
 		},
-		{
+		"struct_nested": {
 			struct {
 				Name  string
 				Age   int
@@ -96,7 +102,7 @@ func TestToValue(t *testing.T) {
 		},
 
 		// Nested structs.
-		{
+		"nested_structs": {
 			struct {
 				Person struct {
 					Name string
@@ -114,7 +120,7 @@ func TestToValue(t *testing.T) {
 		},
 
 		// Structs with tagged fields.
-		{
+		"struct_starlark_tags": {
 			struct {
 				Name string `starlark:"name"`
 				Age  int    `starlark:"age"`
@@ -126,7 +132,7 @@ func TestToValue(t *testing.T) {
 				return dict
 			}(),
 		},
-		{
+		"struct_starlark_json_tags": {
 			struct {
 				A string `starlark:"a" json:"aa"`
 				B int    `starlark:"b" json:"bb"`
@@ -138,7 +144,7 @@ func TestToValue(t *testing.T) {
 				return dict
 			}(),
 		},
-		{
+		"struct_json_tags": {
 			struct {
 				A string `json:"a"`
 				B int    `json:"b"`
@@ -152,15 +158,15 @@ func TestToValue(t *testing.T) {
 		},
 
 		// Custom types.
-		{
+		"customString": {
 			customString("foobar"),
 			starlark.String("foobar"),
 		},
-		{
+		"customBool": {
 			customBool(true),
 			starlark.Bool(true),
 		},
-		{
+		"struct_custom_types": {
 			struct {
 				Type   customString `starlark:"type"`
 				Active customBool   `starlark:"active"`
@@ -174,14 +180,28 @@ func TestToValue(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(fmt.Sprintf("%T", tc.in), func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			got, err := To(tc.in)
 			if err != nil {
 				t.Fatalf("ToValue(%v) returned error: %v", tc.in, err)
 			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("ToValue(%v) = %v, want %v", tc.in, got, tc.want)
+
+			// Special case for NaN because reflect.DeepEqual(NaN, NaN) is false.
+			if f, ok := tc.in.(float64); ok && math.IsNaN(f) {
+				if gotFloat, ok := got.(starlark.Float); ok && math.IsNaN(float64(gotFloat)) {
+					return
+				}
+				t.Errorf("ToValue(%v) = %v, want NaN", tc.in, got)
+				return
+			}
+
+			eq, err := starlark.Equal(got, tc.want)
+			if err != nil {
+				t.Errorf("ToValue(%v) = %v, got error when comparing: %v", tc.in, got, err)
+			}
+			if !eq {
+				t.Errorf("ToValue(%v) = %v (%T), want %v (%T)", tc.in, got, got, tc.want, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Use math.MinInt64 instead of math.MinInt to consistently align with the int64 cast across all architectures. Use -float64(math.MinInt64) as an exclusive upper bound to correctly handle float64 precision.

Add comprehensive test cases for boundary values, NaN, and Inf. Refactor TestToValue to use table-driven tests with a map.

Assisted-by: Jules