### PR TITLE
all: preallocate slice and map capacities

### DIFF
--- a/cmd/audiorenamer/main_test.go
+++ b/cmd/audiorenamer/main_test.go
@@ -155,7 +155,7 @@ func TestRun(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				var got []string
+				got := make([]string, 0, len(gotEntries))
 				for _, e := range gotEntries {
 					got = append(got, e.Name())
 				}

--- a/cmd/starlet/internal/bot/bot_test.go
+++ b/cmd/starlet/internal/bot/bot_test.go
@@ -59,7 +59,7 @@ func TestHandleTelegramWebhook(t *testing.T) {
 		}
 		upd = json.RawMessage(b)
 
-		files := make(map[string]string)
+		files := make(map[string]string, len(ar.Files))
 		for _, f := range ar.Files {
 			files[f.Name] = string(f.Data)
 		}

--- a/cmd/starlet/main.go
+++ b/cmd/starlet/main.go
@@ -169,7 +169,7 @@ func (e *engine) doInit(ctx context.Context) error {
 		}
 	}
 
-	var scrubPairs []string
+	scrubPairs := make([]string, 0, 10)
 	for _, val := range []string{
 		e.ghToken,
 		e.gistID,
@@ -279,7 +279,7 @@ func (e *engine) loadFromGist(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	files := make(map[string]string)
+	files := make(map[string]string, len(g.Files))
 	for name, file := range g.Files {
 		files[name] = file.Content
 	}

--- a/cmd/tgfeed/internal/admin/admin.go
+++ b/cmd/tgfeed/internal/admin/admin.go
@@ -372,7 +372,7 @@ func (a *api) handleGetStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Filter for JSON files.
-	var statsFiles []string
+	statsFiles := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
 			statsFiles = append(statsFiles, entry.Name())
@@ -389,7 +389,7 @@ func (a *api) handleGetStats(w http.ResponseWriter, r *http.Request) {
 		statsFiles = statsFiles[:100]
 	}
 
-	var allStats []statsItem
+	allStats := make([]statsItem, 0, len(statsFiles))
 	for _, name := range statsFiles {
 		path := filepath.Join(a.statsDir, name)
 		b, err := os.ReadFile(path)

--- a/cmd/tgfeed/internal/diff/diff.go
+++ b/cmd/tgfeed/internal/diff/diff.go
@@ -190,7 +190,7 @@ func tgs(x, y []string) []pair {
 	// We only care about 0, 1, many, counted as 0, -1, -2
 	// for the x side and 0, -4, -8 for the y side.
 	// Using negative numbers now lets us distinguish positive line numbers later.
-	m := make(map[string]int)
+	m := make(map[string]int, len(x)+len(y))
 	for _, s := range x {
 		if c := m[s]; c > -2 {
 			m[s] = c - 1

--- a/cmd/tgfeed/internal/format/format.go
+++ b/cmd/tgfeed/internal/format/format.go
@@ -312,11 +312,11 @@ func DefaultUpdateMessage(u Update, defaultTitle string, messageTemplate string)
 // ItemToStarlark converts an RSS item into a Starlark struct used by feed
 // formatter functions.
 func ItemToStarlark(item *gofeed.Item) starlark.Value {
-	var categories []starlark.Value
+	categories := make([]starlark.Value, 0, len(item.Categories))
 	for _, category := range item.Categories {
 		categories = append(categories, starlark.String(category))
 	}
-	var enclosures []starlark.Value
+	enclosures := make([]starlark.Value, 0, len(item.Enclosures))
 	for _, enc := range item.Enclosures {
 		enclosures = append(enclosures, starlarkstruct.FromStringDict(
 			starlarkstruct.Default,

--- a/cmd/tgfeed/internal/telegram/sender.go
+++ b/cmd/tgfeed/internal/telegram/sender.go
@@ -298,7 +298,7 @@ func splitMessageCap(text string, firstChunkCap int) []string {
 		return []string{text}
 	}
 
-	var chunks []string
+	chunks := make([]string, 0, len(runes)/firstChunkCap+1)
 	limit := firstChunkCap
 
 	start := 0

--- a/cmd/tgfeed/internal/telegram/sender_test.go
+++ b/cmd/tgfeed/internal/telegram/sender_test.go
@@ -86,7 +86,7 @@ func TestSendRateLimitRetry(t *testing.T) {
 		}
 		return nil
 	}
-	var waits []time.Duration
+	waits := make([]time.Duration, 0, 1)
 	s.sleep = func(_ context.Context, d time.Duration) bool {
 		waits = append(waits, d)
 		return true


### PR DESCRIPTION
Preallocated slice and map capacities where feasible and appropriate. This optimizes performance by reducing memory allocations and slice expansions.

---
*PR created automatically by Jules for task [14626093909754040245](https://jules.google.com/task/14626093909754040245) started by @astrophena*