### PR TITLE
cmd/tgfeed: fix command injection in EDITOR execution

### DIFF
--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -281,6 +281,11 @@ func (f *fetcher) edit(ctx context.Context) error {
 		return errNoEditor
 	}
 
+	editorPath, err := exec.LookPath(editor)
+	if err != nil {
+		return fmt.Errorf("invalid EDITOR %q: %w", editor, err)
+	}
+
 	if err := f.loadState(ctx); err != nil {
 		return err
 	}
@@ -299,7 +304,7 @@ func (f *fetcher) edit(ctx context.Context) error {
 	}
 
 	for {
-		cmd := exec.Command(editor, tmpfile.Name())
+		cmd := exec.Command(editorPath, tmpfile.Name())
 		cmd.Stdin = env.Stdin
 		cmd.Stdout = env.Stdout
 		cmd.Stderr = env.Stderr


### PR DESCRIPTION
Address a potential command injection vulnerability in tgfeed by resolving and validating the EDITOR environment variable via exec.LookPath before passing it to exec.Command. This prevents the execution of an external command derived from an environment variable without prior sanitization.

Assisted-by: Jules