### PR TITLE
cmd/tgfeed: fix duplicate message sends for feeds with missing dates

### DIFF
--- a/cmd/tgfeed/fetch.go
+++ b/cmd/tgfeed/fetch.go
@@ -396,23 +396,29 @@ func (f *fetcher) enqueueFeedItems(fd *feed, state *state.Feed, exists bool, ite
 }
 
 func (f *fetcher) prepareSeenItemsState(fd *feed, state *state.Feed) (justEnabled bool) {
-	if !fd.alwaysSendNewItems {
-		return false
-	}
 	justEnabled, pruned := state.PrepareSeenItems(time.Now(), seenItemsCleanupPeriod)
 	f.stats.WriteAccess(func(s *stats) {
 		s.SeenItemsPrunedTotal += pruned
 	})
+	if !fd.alwaysSendNewItems {
+		return false
+	}
 	return justEnabled
 }
 
 func decideFeedItem(itemCtx feedItemContext, feedItem *gofeed.Item) feedItemDecision {
+	itemDate := feedItem.PublishedParsed
+	if feedItem.UpdatedParsed != nil {
+		itemDate = feedItem.UpdatedParsed
+	}
+
+	guid := cmp.Or(feedItem.GUID, feedItem.Link)
+
 	if itemCtx.feed.alwaysSendNewItems {
 		now := time.Now()
-		if feedItem.PublishedParsed != nil && now.Sub(*feedItem.PublishedParsed) > lookbackPeriod {
+		if itemDate != nil && now.Sub(*itemDate) > lookbackPeriod {
 			return feedItemDecision{selection: feedItemSelectionSkip, reason: feedItemSkipReasonOld}
 		}
-		guid := cmp.Or(feedItem.GUID, feedItem.Link)
 		if itemCtx.state.IsSeen(guid) {
 			return feedItemDecision{selection: feedItemSelectionSkip, reason: feedItemSkipReasonSeen}
 		}
@@ -424,10 +430,19 @@ func decideFeedItem(itemCtx feedItemContext, feedItem *gofeed.Item) feedItemDeci
 		return decision
 	}
 
-	if feedItem.PublishedParsed != nil && feedItem.PublishedParsed.Before(itemCtx.state.LastUpdated) {
+	if itemCtx.state.IsSeen(guid) {
+		return feedItemDecision{selection: feedItemSelectionSkip, reason: feedItemSkipReasonSeen}
+	}
+
+	if itemDate != nil && itemDate.Before(itemCtx.state.LastUpdated) {
 		return feedItemDecision{selection: feedItemSelectionSkip, reason: feedItemSkipReasonOld}
 	}
-	return feedItemDecision{selection: feedItemSelectionProcess}
+
+	if itemDate == nil && !itemCtx.exists {
+		return feedItemDecision{selection: feedItemSelectionMarkSeenOnly, markSeen: guid}
+	}
+
+	return feedItemDecision{selection: feedItemSelectionProcess, markSeen: guid}
 }
 
 func (f *fetcher) decideEnqueueAction(itemCtx feedItemContext, feedItem *gofeed.Item) enqueueAction {

--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -391,7 +391,7 @@ func TestDecideFeedItem(t *testing.T) {
 			exists:        true,
 			justEnabled:   false,
 			wantSelection: feedItemSelectionProcess,
-			wantMarkSeen:  "",
+			wantMarkSeen:  "regular-nil",
 		},
 	}
 

--- a/cmd/tgfeed/state_test.go
+++ b/cmd/tgfeed/state_test.go
@@ -334,7 +334,10 @@ func TestFeedStateItemDecisions(t *testing.T) {
 				GUID: "regular-nil",
 				Link: "https://example.com/regular-nil",
 			},
+			exists:        true,
 			wantSelection: feedItemSelectionProcess,
+			wantMarkSeen:  "regular-nil",
+			wantReason:    feedItemSkipReasonNone,
 		},
 	}
 


### PR DESCRIPTION
Fixes a bug where `tgfeed` repeatedly sends the same feed item from feeds that are missing standard `<updated>` or easily parseable `<pubDate>` timestamps.

The fix handles this by correctly falling back to `UpdatedParsed` and expanding the use of `IsSeen` logic and the `SeenItems` state tracking map to cover all items processed, not just those where `always_send_new_items=True`.

---
*PR created automatically by Jules for task [17094023057080013142](https://jules.google.com/task/17094023057080013142) started by @astrophena*