### PR TITLE
cmd/starlet: fix panic in admin endpoint

### DIFF
--- a/cmd/starlet/main.go
+++ b/cmd/starlet/main.go
@@ -43,7 +43,6 @@ type engine struct {
 	mux      *http.ServeMux
 	adminMux *http.ServeMux
 	scrubber *strings.Replacer
-	srv      *web.Server
 	store    store.Store
 
 	// configuration, read-only after initialization

--- a/cmd/starlet/routes.go
+++ b/cmd/starlet/routes.go
@@ -74,7 +74,7 @@ func (e *engine) initRoutes() {
 			MainCSS       string
 			Documentation template.HTML
 		}{
-			MainCSS:       e.srv.StaticHashName("static/css/main.css"),
+			MainCSS:       web.StaticHashName(r.Context(), "static/css/main.css"),
 			Documentation: docs,
 		}
 		if err := templates().ExecuteTemplate(&buf, "env.tmpl", data); err != nil {
@@ -130,7 +130,7 @@ func (e *engine) debugMenu(r *http.Request) []web.MenuItem {
 			name:       name,
 			icon:       icon,
 			target:     target,
-			spritePath: e.srv.StaticHashName("static/icons/sprite.svg"),
+			spritePath: web.StaticHashName(r.Context(), "static/icons/sprite.svg"),
 		}
 	}
 


### PR DESCRIPTION
Forgot to remove old pointer to web.Server from engine.
Currently is better to use web.StaticHashName(ctx, ...).
