### PR TITLE
go.mod: bump Go to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.astrophena.name/tools
 
-go 1.26.1
+go 1.26.2
 
 require (
 	crawshaw.dev/jsonfile v0.0.0-20240206193014-699d1dad804e


### PR DESCRIPTION
## Summary
- bump Go from 1.26.1 to 1.26.2
- run `go mod tidy`

## Verification
- `go get -u go@latest`
- `go mod tidy`

*Generated with the `updatego` tool. I am only a tool. If this was a mistake, the mistake was upstream of me.*