### PR TITLE
cmd/tgfeed: count exhausted retries as failures

### DIFF
--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,6 +43,40 @@ func TestFailingFeed(t *testing.T) {
 
 	testutil.AssertEqual(t, state[atomFeedURL].ErrorCount, 1)
 	testutil.AssertEqual(t, state[atomFeedURL].LastError, "want 200, got 418: I'm a teapot.\n")
+}
+
+func TestRetryExhaustionCountsAsFailure(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	env := newDefaultTestEnv(t, map[string]http.HandlerFunc{
+		atomFeedRoute: func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		},
+	})
+	f := newTestFetcher(t, env)
+	if err := f.run(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	state := env.state(t)
+
+	testutil.AssertEqual(t, attempts.Load(), int32(retryLimit+1))
+	testutil.AssertEqual(t, state[atomFeedURL].ErrorCount, 1)
+	testutil.AssertEqual(t, state[atomFeedURL].FetchFailCount, int64(1))
+	if !strings.Contains(state[atomFeedURL].LastError, fmt.Sprintf("retry limit exceeded after %d retries", retryLimit)) {
+		t.Fatalf("unexpected last error: %q", state[atomFeedURL].LastError)
+	}
+
+	f.stats.ReadAccess(func(s *stats) {
+		testutil.AssertEqual(t, s.FailedFeeds, 1)
+		testutil.AssertEqual(t, s.SuccessFeeds, 0)
+		testutil.AssertEqual(t, s.NotModifiedFeeds, 0)
+		testutil.AssertEqual(t, s.FetchRetriesTotal, retryLimit)
+		testutil.AssertEqual(t, s.FeedsRetriedCount, 1)
+		testutil.AssertEqual(t, s.HTTP5xxCount, retryLimit+1)
+	})
 }
 
 func TestDisablingAndReenablingFailingFeed(t *testing.T) {

--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -236,48 +236,7 @@ func (f *fetcher) run(ctx context.Context) error {
 	for _, feed := range shuffle(f.feeds) {
 		fetchWg.Go(func() {
 			defer fetchedFeeds.Add(1)
-
-			var retries int
-			var feedRetried bool
-
-			for {
-				if retry, retryIn := f.fetch(ctx, feed, updates); retry && retries < retryLimit {
-					if retryIn > maxRetryTime {
-						f.slog.Warn("feed retry time is too long, not retrying at all",
-							"feed", feed.url,
-							"retry_in", retryIn.String(),
-							"max_retry_time", maxRetryTime.String(),
-						)
-						break
-					}
-
-					feedRetried = true
-					f.stats.WriteAccess(func(s *stats) {
-						s.FetchRetriesTotal += 1
-						s.BackoffSleepTotal += retryIn
-						s.feedStats(feed.url).Retries += 1
-						s.SpecialRateLimitRetries += 1
-					})
-					f.slog.Warn("retrying feed",
-						"feed", feed.url,
-						"retry_in", retryIn.String(),
-						"retries", retries+1,
-						"retry_limit", retryLimit,
-					)
-					if !sleep(ctx, retryIn) {
-						break
-					}
-					retries += 1
-					continue
-				}
-				break
-			}
-
-			if feedRetried {
-				f.stats.WriteAccess(func(s *stats) {
-					s.FeedsRetriedCount += 1
-				})
-			}
+			f.runFeedFetch(ctx, feed, updates)
 		})
 	}
 
@@ -352,6 +311,59 @@ func (f *fetcher) run(ctx context.Context) error {
 	})
 
 	return nil
+}
+
+func (f *fetcher) runFeedFetch(ctx context.Context, fd *feed, updates chan *update) {
+	var retries int
+	var feedRetried bool
+
+	for {
+		retry, retryIn := f.fetch(ctx, fd, updates)
+		if !retry {
+			break
+		}
+		if !f.retryFeedFetch(ctx, fd, retries, retryIn) {
+			break
+		}
+		feedRetried = true
+		retries += 1
+	}
+
+	if feedRetried {
+		f.stats.WriteAccess(func(s *stats) {
+			s.FeedsRetriedCount += 1
+		})
+	}
+}
+
+func (f *fetcher) retryFeedFetch(ctx context.Context, fd *feed, retries int, retryIn time.Duration) bool {
+	if retries >= retryLimit {
+		f.handleFetchFailure(ctx, fd.url, fmt.Errorf("retry limit exceeded after %d retries", retries))
+		return false
+	}
+	if retryIn > maxRetryTime {
+		f.slog.Warn("feed retry time is too long, not retrying at all",
+			"feed", fd.url,
+			"retry_in", retryIn.String(),
+			"max_retry_time", maxRetryTime.String(),
+		)
+		f.handleFetchFailure(ctx, fd.url, fmt.Errorf("retry wait %s exceeds max retry time %s", retryIn, maxRetryTime))
+		return false
+	}
+
+	f.stats.WriteAccess(func(s *stats) {
+		s.FetchRetriesTotal += 1
+		s.BackoffSleepTotal += retryIn
+		s.feedStats(fd.url).Retries += 1
+		s.SpecialRateLimitRetries += 1
+	})
+	f.slog.Warn("retrying feed",
+		"feed", fd.url,
+		"retry_in", retryIn.String(),
+		"retries", retries+1,
+		"retry_limit", retryLimit,
+	)
+	return sleep(ctx, retryIn)
 }
 
 func (f *fetcher) cleanState(ctx context.Context) error {


### PR DESCRIPTION
Feeds that end a run in a retryable state could disappear from latest-run stats without incrementing failed_feeds. That made the admin UI show fewer healthy feeds than total feeds even when failed_feeds stayed at zero.

Move the per-feed retry loop into helpers that turn exhausted retry states into terminal failures, and add a regression test for a feed that stays on 503 until the retry budget is exhausted.

Assisted-by: Codex (GPT-5)
