### PR TITLE
cmd/tgfeed: drop legacy stats json migration

### DIFF
--- a/cmd/tgfeed/internal/admin/admin_test.go
+++ b/cmd/tgfeed/internal/admin/admin_test.go
@@ -51,8 +51,17 @@ func TestAdmin(t *testing.T) {
 		if err := statsStore.Bootstrap(t.Context()); err != nil {
 			t.Fatalf("bootstrapping stats store: %v", err)
 		}
-		if _, err := statsStore.MigrateJSONDir(t.Context(), filepath.Join(stateDir, "stats")); err != nil {
-			t.Fatalf("migrating legacy stats: %v", err)
+		if fs != nil {
+			if err := statsStore.SaveRun(t.Context(), &stats.Run{
+				StartTime: time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC),
+			}); err != nil {
+				t.Fatalf("saving first stats run: %v", err)
+			}
+			if err := statsStore.SaveRun(t.Context(), &stats.Run{
+				StartTime: time.Date(2023, time.January, 2, 12, 0, 0, 0, time.UTC),
+			}); err != nil {
+				t.Fatalf("saving second stats run: %v", err)
+			}
 		}
 
 		return Config{
@@ -90,11 +99,9 @@ func TestAdmin(t *testing.T) {
 	}
 
 	initialFS := fstest.MapFS{
-		"config.star":  {Data: []byte(`feed(url="https://example.com")`)},
-		"state.json":   {Data: []byte(`{}`)},
-		"error.tmpl":   {Data: []byte(`Custom error: %v`)},
-		"stats/a.json": {Data: []byte(`{"start_time":"2023-01-01T12:00:00Z"}`)},
-		"stats/b.json": {Data: []byte(`{"start_time":"2023-01-02T12:00:00Z"}`)},
+		"config.star": {Data: []byte(`feed(url="https://example.com")`)},
+		"state.json":  {Data: []byte(`{}`)},
+		"error.tmpl":  {Data: []byte(`Custom error: %v`)},
 	}
 
 	t.Run("get config", func(t *testing.T) {

--- a/cmd/tgfeed/internal/stats/migrations/2-jsonb.sql
+++ b/cmd/tgfeed/internal/stats/migrations/2-jsonb.sql
@@ -1,15 +1,9 @@
-PRAGMA journal_mode = WAL;
-PRAGMA synchronous = NORMAL;
-PRAGMA temp_store = MEMORY;
-PRAGMA foreign_keys = ON;
-PRAGMA busy_timeout = 5000;
-
-CREATE TABLE IF NOT EXISTS runs (
+CREATE TABLE IF NOT EXISTS runs_new (
   run_id INTEGER PRIMARY KEY,
   started_at_unix INTEGER NOT NULL,
   finished_at_unix INTEGER NOT NULL,
   duration_ms INTEGER NOT NULL,
-  payload_json TEXT NOT NULL CHECK (json_valid(payload_json, 5)),
+  payload_json BLOB NOT NULL CHECK (json_valid(payload_json, 5)),
   payload_sha256 TEXT NOT NULL,
   total_feeds INTEGER GENERATED ALWAYS AS (json_extract(payload_json, '$.total_feeds')) STORED,
   success_feeds INTEGER GENERATED ALWAYS AS (json_extract(payload_json, '$.success_feeds')) STORED,
@@ -17,13 +11,15 @@ CREATE TABLE IF NOT EXISTS runs (
   messages_failed INTEGER GENERATED ALWAYS AS (json_extract(payload_json, '$.messages_failed')) STORED
 ) STRICT;
 
+INSERT INTO runs_new(run_id, started_at_unix, finished_at_unix, duration_ms, payload_json, payload_sha256)
+SELECT run_id, started_at_unix, finished_at_unix, duration_ms, jsonb(payload_json), payload_sha256
+FROM runs;
+
+DROP TABLE runs;
+ALTER TABLE runs_new RENAME TO runs;
+
 CREATE UNIQUE INDEX IF NOT EXISTS runs_started_payload_uq ON runs(started_at_unix, payload_sha256);
 CREATE INDEX IF NOT EXISTS runs_started_desc_idx ON runs(started_at_unix DESC);
 CREATE INDEX IF NOT EXISTS runs_failed_started_idx ON runs(failed_feeds DESC, started_at_unix DESC);
 CREATE INDEX IF NOT EXISTS runs_problematic_partial_idx ON runs(started_at_unix DESC)
 WHERE failed_feeds > 0 OR messages_failed > 0;
-
-CREATE TABLE IF NOT EXISTS meta (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL
-) STRICT;

--- a/cmd/tgfeed/internal/stats/store.go
+++ b/cmd/tgfeed/internal/stats/store.go
@@ -11,7 +11,6 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -20,14 +19,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	_ "github.com/tailscale/sqlite"
 )
 
 const dbFileName = "stats.sqlite3"
 
-const currentSchemaVersion = 1
+const currentSchemaVersion = 2
 
 //go:embed migrations/*.sql
 var migrationsFS embed.FS
@@ -126,7 +124,7 @@ func (s *Store) SaveRun(ctx context.Context, run *Run) error {
 	_, err = db.ExecContext(
 		ctx,
 		`INSERT OR IGNORE INTO runs(started_at_unix, finished_at_unix, duration_ms, payload_json, payload_sha256)
-		VALUES(?, ?, ?, ?, ?);`,
+		VALUES(?, ?, ?, jsonb(?), ?);`,
 		started,
 		finished,
 		durationMS,
@@ -148,7 +146,7 @@ func (s *Store) ListRuns(ctx context.Context, limit int) ([]json.RawMessage, err
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT payload_json FROM runs ORDER BY started_at_unix DESC LIMIT ?;`,
+		`SELECT json(payload_json) FROM runs ORDER BY started_at_unix DESC LIMIT ?;`,
 		limit,
 	)
 	if err != nil {
@@ -168,87 +166,6 @@ func (s *Store) ListRuns(ctx context.Context, limit int) ([]json.RawMessage, err
 		return nil, err
 	}
 	return res, nil
-}
-
-// MarkMigrationComplete records completion of JSON migration.
-func (s *Store) MarkMigrationComplete(ctx context.Context) error {
-	db, err := s.open(ctx)
-	if err != nil {
-		return err
-	}
-
-	_, err = db.ExecContext(
-		ctx,
-		`INSERT INTO meta(key, value) VALUES('legacy_json_migrated', '1')
-		ON CONFLICT(key) DO UPDATE SET value=excluded.value;`,
-	)
-	return err
-}
-
-// MigrationCompleted reports whether JSON migration marker exists.
-func (s *Store) MigrationCompleted(ctx context.Context) (bool, error) {
-	db, err := s.open(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	var value string
-	err = db.QueryRowContext(ctx, `SELECT value FROM meta WHERE key='legacy_json_migrated';`).Scan(&value)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return value == "1", nil
-}
-
-// MigrateJSONDir imports legacy JSON run snapshots.
-func (s *Store) MigrateJSONDir(ctx context.Context, statsDir string) (int, error) {
-	if s.readOnly {
-		return 0, nil
-	}
-	entries, err := os.ReadDir(statsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
-		}
-		return 0, err
-	}
-	files := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
-			continue
-		}
-		files = append(files, entry.Name())
-	}
-	slices.Sort(files)
-
-	migrated := 0
-	for _, name := range files {
-		path := filepath.Join(statsDir, name)
-		b, err := os.ReadFile(path)
-		if err != nil {
-			return migrated, err
-		}
-		var run Run
-		if err := json.Unmarshal(b, &run); err != nil {
-			return migrated, fmt.Errorf("%s: %w", path, err)
-		}
-		if run.StartTime.IsZero() {
-			if ts, err := strconv.ParseInt(strings.TrimSuffix(name, ".json"), 10, 64); err == nil {
-				run.StartTime = time.Unix(ts, 0).UTC()
-			}
-		}
-		if err := s.SaveRun(ctx, &run); err != nil {
-			return migrated, err
-		}
-		migrated += 1
-	}
-	if err := s.MarkMigrationComplete(ctx); err != nil {
-		return migrated, err
-	}
-	return migrated, nil
 }
 
 func (s *Store) open(ctx context.Context) (*sql.DB, error) {

--- a/cmd/tgfeed/internal/stats/store_test.go
+++ b/cmd/tgfeed/internal/stats/store_test.go
@@ -6,8 +6,6 @@ package stats
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -71,7 +69,7 @@ func TestStoreSaveRunAndListRuns(t *testing.T) {
 	testutil.AssertEqual(t, version, currentSchemaVersion)
 }
 
-func TestStoreMigrateJSONDir(t *testing.T) {
+func TestStoreSaveRunUsesJSONB(t *testing.T) {
 	t.Parallel()
 
 	store := OpenMemory(t.Name())
@@ -85,27 +83,30 @@ func TestStoreMigrateJSONDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	statsDir := t.TempDir()
-	firstRun := `{"start_time":"2023-01-01T12:00:00Z","total_feeds":1}`
-	secondRun := `{"total_feeds":2}`
-	if err := os.WriteFile(filepath.Join(statsDir, "1672574400.json"), []byte(firstRun), 0o644); err != nil {
+	if err := store.SaveRun(t.Context(), &Run{
+		StartTime:  time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC),
+		TotalFeeds: 1,
+	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(statsDir, "1672660800.json"), []byte(secondRun), 0o644); err != nil {
+	if err := store.SaveRun(t.Context(), &Run{
+		StartTime:  time.Date(2023, time.January, 2, 12, 0, 0, 0, time.UTC),
+		TotalFeeds: 2,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	migrated, err := store.MigrateJSONDir(t.Context(), statsDir)
+	db, err := store.open(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
-	testutil.AssertEqual(t, migrated, 2)
 
-	done, err := store.MigrationCompleted(t.Context())
+	var payloadType string
+	err = db.QueryRowContext(t.Context(), `SELECT typeof(payload_json) FROM runs LIMIT 1;`).Scan(&payloadType)
 	if err != nil {
 		t.Fatal(err)
 	}
-	testutil.AssertEqual(t, done, true)
+	testutil.AssertEqual(t, payloadType, "blob")
 
 	runs, err := store.ListRuns(t.Context(), 10)
 	if err != nil {

--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -197,11 +197,6 @@ func (f *fetcher) run(ctx context.Context) error {
 	if err := f.statsStore.Bootstrap(ctx); err != nil {
 		return fmt.Errorf("bootstrapping stats database failed: %w", err)
 	}
-	if migrated, err := f.statsStore.MigrateJSONDir(ctx, filepath.Join(f.stateDir, "stats")); err != nil {
-		return fmt.Errorf("migrating legacy stats failed: %w", err)
-	} else if migrated > 0 {
-		f.slog.Info("migrated legacy stats into SQLite", "count", migrated)
-	}
 
 	if err := f.loadState(ctx); err != nil {
 		return fmt.Errorf("loading state failed: %w", err)


### PR DESCRIPTION
## Summary
- remove the legacy `stats/*.json` import path from tgfeed run startup and from the stats store API
- switch stats payload writes to SQLite JSONB via `jsonb(?)` and decode reads via `json(payload_json)`
- add schema migration `2-jsonb.sql` to convert existing `runs.payload_json` values from JSON text to JSONB in SQL
- update tests to seed stats directly through `SaveRun` instead of loading legacy JSON files

## Verification
- `go test ./cmd/tgfeed/internal/stats ./cmd/tgfeed/internal/admin`
- `go test ./cmd/tgfeed`


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08e865a5c8323bcff5d11feb73d49)