### PR TITLE
cmd/tgfeed: simplify sender and state surfaces

### DIFF
--- a/cmd/tgfeed/fetch.go
+++ b/cmd/tgfeed/fetch.go
@@ -71,7 +71,6 @@ type feedStatusResult struct {
 	handled bool
 	retry   bool
 	retryIn time.Duration
-	class   int
 }
 
 // feedItemDecision captures both item processing and seen-state updates.
@@ -275,7 +274,6 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 		})
 		return feedStatusResult{
 			handled: true,
-			class:   3,
 		}, nil
 	}
 	if res.StatusCode == http.StatusOK {
@@ -283,7 +281,7 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 			s.HTTP2xxCount += 1
 			s.FeedStats(fd.url).LastStatusClass = 2
 		})
-		return feedStatusResult{class: 2}, nil
+		return feedStatusResult{}, nil
 	}
 
 	f.stats.WriteAccess(func(s *stats.Run) {
@@ -300,7 +298,6 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 				handled: true,
 				retry:   true,
 				retryIn: t,
-				class:   4,
 			}, nil
 		}
 	}
@@ -317,7 +314,6 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 					handled: true,
 					retry:   true,
 					retryIn: t,
-					class:   res.StatusCode / 100,
 				}, nil
 			}
 			f.slog.Warn("rate-limited (Retry-After), but wait time is too long", "feed", fd.url, "retry_in", t.String(), "max_retry_in", maxRetryAfter.String())
@@ -330,13 +326,11 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 			handled: true,
 			retry:   true,
 			retryIn: 5 * time.Second,
-			class:   res.StatusCode / 100,
 		}, nil
 	}
 
 	return feedStatusResult{
 		handled: true,
-		class:   res.StatusCode / 100,
 	}, fmt.Errorf("want 200, got %d: %s", res.StatusCode, body)
 }
 
@@ -583,7 +577,7 @@ func (f *fetcher) sendUpdate(ctx context.Context, u *update) {
 	if err := f.sender.Send(ctx, sender.Message{
 		Body: strings.TrimSpace(rendered.Body),
 		Target: sender.Target{
-			Topic: strconv.FormatInt(u.feed.messageThreadID, 10),
+			Thread: strconv.FormatInt(u.feed.messageThreadID, 10),
 		},
 		Options: sender.Options{
 			SuppressLinkPreview: rendered.DisablePreview,
@@ -649,7 +643,7 @@ func (f *fetcher) errNotify(ctx context.Context, err error) error {
 	return f.sender.Send(ctx, sender.Message{
 		Body: fmt.Sprintf(tmpl, err),
 		Target: sender.Target{
-			Topic: strconv.FormatInt(f.errorThreadID, 10),
+			Thread: strconv.FormatInt(f.errorThreadID, 10),
 		},
 		Options: sender.Options{
 			SuppressLinkPreview: true,

--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -688,7 +688,7 @@ func TestSendUpdateUsesInjectedSender(t *testing.T) {
 
 	f.sendUpdate(t.Context(), u)
 	testutil.AssertEqual(t, len(mock.messages), 1)
-	testutil.AssertEqual(t, mock.messages[0].Target.Topic, "7")
+	testutil.AssertEqual(t, mock.messages[0].Target.Thread, "7")
 	if !strings.Contains(mock.messages[0].Body, "hello") {
 		t.Fatalf("sent body %q does not include title", mock.messages[0].Body)
 	}

--- a/cmd/tgfeed/internal/admin/admin.go
+++ b/cmd/tgfeed/internal/admin/admin.go
@@ -29,6 +29,22 @@ import (
 
 var errConflict = web.StatusErr(http.StatusConflict)
 
+// Store reads and writes the persisted resources exposed by the admin API.
+type Store interface {
+	// LoadConfig loads tgfeed Starlark configuration.
+	LoadConfig(ctx context.Context) (string, error)
+	// LoadState loads persisted feed runtime state.
+	LoadState(ctx context.Context) (map[string]*state.Feed, error)
+	// LoadErrorTemplate loads the current error template.
+	LoadErrorTemplate(ctx context.Context) (string, error)
+	// SaveConfig persists tgfeed Starlark configuration.
+	SaveConfig(ctx context.Context, config string) error
+	// SaveStateJSON persists pre-encoded feed runtime state.
+	SaveStateJSON(ctx context.Context, content []byte) error
+	// SaveErrorTemplate persists the error template.
+	SaveErrorTemplate(ctx context.Context, content string) error
+}
+
 // Config configures the tgfeed admin HTTP API.
 type Config struct {
 	// Addr is the network address passed to [web.Server].
@@ -36,7 +52,7 @@ type Config struct {
 	// StateDir is tgfeed's local state directory.
 	StateDir string
 	// Store reads and writes tgfeed persisted state.
-	Store state.Store
+	Store Store
 	// ValidateConfig validates a Starlark config before persisting it.
 	ValidateConfig func(ctx context.Context, content string) error
 	// IsRunLocked reports whether tgfeed run lock is currently held.
@@ -204,7 +220,7 @@ func normalizeConfig(cfg Config) (Config, error) {
 }
 
 type api struct {
-	store            state.Store
+	store            Store
 	validateConfigFn func(context.Context, string) error
 	isRunLocked      func() bool
 	statsStore       *stats.Store

--- a/cmd/tgfeed/internal/sender/sender.go
+++ b/cmd/tgfeed/internal/sender/sender.go
@@ -30,7 +30,7 @@ type Media struct {
 // Target identifies where a message should be delivered.
 type Target struct {
 	Channel string
-	Topic   string
+	Thread  string
 }
 
 // Options controls optional message delivery behavior.

--- a/cmd/tgfeed/internal/state/feedset.go
+++ b/cmd/tgfeed/internal/state/feedset.go
@@ -18,11 +18,11 @@ import (
 type FeedSet struct {
 	mu    sync.RWMutex
 	feeds map[string]*Feed
-	store Store
+	store *Store
 }
 
 // NewFeedSet builds a mutable state set from an existing snapshot.
-func NewFeedSet(store Store, feeds map[string]*Feed) *FeedSet {
+func NewFeedSet(store *Store, feeds map[string]*Feed) *FeedSet {
 	if feeds == nil {
 		feeds = map[string]*Feed{}
 	}

--- a/cmd/tgfeed/internal/state/state.go
+++ b/cmd/tgfeed/internal/state/state.go
@@ -73,28 +73,6 @@ type Snapshot struct {
 	ErrorTemplate string
 }
 
-// Store reads and writes tgfeed persisted state.
-//
-// It is constructed with [NewStore].
-type Store interface {
-	// LoadSnapshot loads config, feed state, and error template in one call.
-	LoadSnapshot(ctx context.Context) (*Snapshot, error)
-	// LoadConfig loads tgfeed Starlark configuration.
-	LoadConfig(ctx context.Context) (string, error)
-	// LoadState loads persisted feed runtime state.
-	LoadState(ctx context.Context) (map[string]*Feed, error)
-	// LoadErrorTemplate loads the current error template.
-	LoadErrorTemplate(ctx context.Context) (string, error)
-	// SaveConfig persists tgfeed Starlark configuration.
-	SaveConfig(ctx context.Context, config string) error
-	// SaveState persists feed runtime state as formatted JSON.
-	SaveState(ctx context.Context, state map[string]*Feed) error
-	// SaveStateJSON persists pre-encoded state JSON.
-	SaveStateJSON(ctx context.Context, content []byte) error
-	// SaveErrorTemplate persists the error template.
-	SaveErrorTemplate(ctx context.Context, content string) error
-}
-
 // Options configures [NewStore].
 type Options struct {
 	// StateDir is a local directory used when [RemoteURL] is empty.
@@ -111,17 +89,18 @@ type Options struct {
 	DefaultErrorTemplate string
 }
 
-// NewStore constructs a [Store] that persists state locally or remotely,
-// depending on [Options].
-func NewStore(opts Options) Store { return &store{opts: opts} }
+// Store reads and writes tgfeed persisted state.
+type Store struct{ opts Options }
 
-type store struct{ opts Options }
+// NewStore constructs a store that persists state locally or remotely,
+// depending on opts.
+func NewStore(opts Options) *Store { return &Store{opts: opts} }
 
 type errorResponse struct {
 	Error string `json:"error"`
 }
 
-func (s *store) LoadSnapshot(ctx context.Context) (*Snapshot, error) {
+func (s *Store) LoadSnapshot(ctx context.Context) (*Snapshot, error) {
 	config, err := s.LoadConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -137,7 +116,7 @@ func (s *store) LoadSnapshot(ctx context.Context) (*Snapshot, error) {
 	return &Snapshot{Config: config, State: stateMap, ErrorTemplate: errorTemplate}, nil
 }
 
-func (s *store) LoadConfig(ctx context.Context) (string, error) {
+func (s *Store) LoadConfig(ctx context.Context) (string, error) {
 	if s.opts.RemoteURL == "" {
 		configBytes, err := os.ReadFile(filepath.Join(s.opts.StateDir, "config.star"))
 		if err != nil {
@@ -152,7 +131,7 @@ func (s *store) LoadConfig(ctx context.Context) (string, error) {
 	return string(b), nil
 }
 
-func (s *store) LoadState(ctx context.Context) (map[string]*Feed, error) {
+func (s *Store) LoadState(ctx context.Context) (map[string]*Feed, error) {
 	if s.opts.RemoteURL == "" {
 		stateBytes, err := os.ReadFile(filepath.Join(s.opts.StateDir, "state.json"))
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -171,7 +150,7 @@ func (s *store) LoadState(ctx context.Context) (map[string]*Feed, error) {
 	return stateMap, nil
 }
 
-func (s *store) LoadErrorTemplate(ctx context.Context) (string, error) {
+func (s *Store) LoadErrorTemplate(ctx context.Context) (string, error) {
 	if s.opts.RemoteURL == "" {
 		errorTemplateBytes, err := os.ReadFile(filepath.Join(s.opts.StateDir, "error.tmpl"))
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -186,7 +165,7 @@ func (s *store) LoadErrorTemplate(ctx context.Context) (string, error) {
 	return string(b), nil
 }
 
-func (s *store) fetch(ctx context.Context, url string) ([]byte, error) {
+func (s *Store) fetch(ctx context.Context, url string) ([]byte, error) {
 	b, err := request.Make[request.Bytes](ctx, request.Params{Method: http.MethodGet, Headers: map[string]string{"User-Agent": version.UserAgent()}, URL: s.apiURL(url), HTTPClient: s.httpClient()})
 	if err != nil {
 		var statusErr *request.StatusError
@@ -201,7 +180,7 @@ func (s *store) fetch(ctx context.Context, url string) ([]byte, error) {
 	return b, nil
 }
 
-func (s *store) SaveState(ctx context.Context, state map[string]*Feed) error {
+func (s *Store) SaveState(ctx context.Context, state map[string]*Feed) error {
 	b, err := MarshalStateMap(state)
 	if err != nil {
 		return err
@@ -209,7 +188,7 @@ func (s *store) SaveState(ctx context.Context, state map[string]*Feed) error {
 	return s.SaveStateJSON(ctx, b)
 }
 
-func (s *store) SaveStateJSON(ctx context.Context, content []byte) error {
+func (s *Store) SaveStateJSON(ctx context.Context, content []byte) error {
 	if s.opts.RemoteURL == "" {
 		return safefile.WriteFile(filepath.Join(s.opts.StateDir, "state.json"), content, 0o644)
 	}
@@ -220,7 +199,7 @@ func (s *store) SaveStateJSON(ctx context.Context, content []byte) error {
 	return nil
 }
 
-func (s *store) SaveConfig(ctx context.Context, config string) error {
+func (s *Store) SaveConfig(ctx context.Context, config string) error {
 	if s.opts.RemoteURL == "" {
 		return safefile.WriteFile(filepath.Join(s.opts.StateDir, "config.star"), []byte(config), 0o644)
 	}
@@ -231,7 +210,7 @@ func (s *store) SaveConfig(ctx context.Context, config string) error {
 	return nil
 }
 
-func (s *store) SaveErrorTemplate(ctx context.Context, content string) error {
+func (s *Store) SaveErrorTemplate(ctx context.Context, content string) error {
 	if s.opts.RemoteURL == "" {
 		return safefile.WriteFile(filepath.Join(s.opts.StateDir, "error.tmpl"), []byte(content), 0o644)
 	}
@@ -261,7 +240,7 @@ func UnmarshalStateMap(b []byte) (map[string]*Feed, error) {
 	return stateMap, nil
 }
 
-func (s *store) httpClient() *http.Client {
+func (s *Store) httpClient() *http.Client {
 	if strings.HasPrefix(s.opts.RemoteURL, "/") {
 		return &http.Client{Transport: &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", s.opts.RemoteURL)
@@ -270,7 +249,7 @@ func (s *store) httpClient() *http.Client {
 	return s.opts.HTTPClient
 }
 
-func (s *store) apiURL(endpoint string) string {
+func (s *Store) apiURL(endpoint string) string {
 	if strings.HasPrefix(s.opts.RemoteURL, "/") {
 		return "http://unix" + endpoint
 	}

--- a/cmd/tgfeed/internal/telegram/sender.go
+++ b/cmd/tgfeed/internal/telegram/sender.go
@@ -134,10 +134,10 @@ func (s *Sender) Send(ctx context.Context, msg sender.Message) error {
 		chatID = msg.Target.Channel
 	}
 	var threadID int64
-	if msg.Target.Topic != "" {
-		tid, err := strconv.ParseInt(msg.Target.Topic, 10, 64)
+	if msg.Target.Thread != "" {
+		tid, err := strconv.ParseInt(msg.Target.Thread, 10, 64)
 		if err != nil {
-			return fmt.Errorf("parsing target topic as thread id: %w", err)
+			return fmt.Errorf("parsing target thread as thread id: %w", err)
 		}
 		threadID = tid
 	}

--- a/cmd/tgfeed/internal/telegram/sender_test.go
+++ b/cmd/tgfeed/internal/telegram/sender_test.go
@@ -151,11 +151,11 @@ func TestIsRateLimited(t *testing.T) {
 	}
 }
 
-func TestSendInvalidTopic(t *testing.T) {
+func TestSendInvalidThread(t *testing.T) {
 	t.Parallel()
 
 	s := New(Config{ChatID: "chat", Token: "token"})
-	err := s.Send(t.Context(), sender.Message{Body: "hello", Target: sender.Target{Topic: "not-a-number"}})
+	err := s.Send(t.Context(), sender.Message{Body: "hello", Target: sender.Target{Thread: "not-a-number"}})
 	if err == nil {
 		t.Fatal("Send() error = nil, want non-nil")
 	}

--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -89,7 +89,7 @@ type fetcher struct {
 	stats      syncx.Protected[*stats.Run]
 	statsStore *stats.Store
 	sender     sender.Sender
-	store      state.Store
+	store      *state.Store
 
 	runLock filelock.Lock
 }


### PR DESCRIPTION
Stack PR 1/7.

This starts the tgfeed simplification stack by trimming sender/state surfaces before the fetcher state changes.

Next: #336