### PR TITLE
cmd/tgfeed: save feed state at run boundary

### DIFF
--- a/cmd/tgfeed/fetch.go
+++ b/cmd/tgfeed/fetch.go
@@ -144,21 +144,9 @@ type feedItemContext struct {
 func (f *fetcher) fetch(ctx context.Context, fd *feed, updates chan *update) (retry bool, retryIn time.Duration) {
 	startTime := time.Now()
 
-	var (
-		exists       bool
-		disabled     bool
-		etag         string
-		lastModified string
-	)
-	if err := f.updateFeedState(ctx, fd.url, func(state *state.Feed, hasState bool) bool {
-		exists = hasState
-		disabled = state.IsDisabled()
-		etag, lastModified = state.CacheHeaders()
-		return false
-	}); err != nil {
-		f.handleFetchFailure(ctx, fd.url, err)
-		return false, 0
-	}
+	fdState, exists := f.feedState(fd.url)
+	disabled := fdState.IsDisabled()
+	etag, lastModified := fdState.CacheHeaders()
 	if !exists {
 		// If we don't remember this feed, it's probably new. Set its last update
 		// date to current so we don't get a lot of unread articles and trigger
@@ -190,7 +178,7 @@ func (f *fetcher) fetch(ctx context.Context, fd *feed, updates chan *update) (re
 
 	f.logFeedResponse(fd, res)
 
-	status, err := f.handleFeedStatus(req, res, fd)
+	status, err := f.handleFeedStatus(req, res, fd, fdState)
 	if err != nil {
 		f.handleFetchFailure(ctx, fd.url, err)
 		return false, 0
@@ -208,15 +196,9 @@ func (f *fetcher) fetch(ctx context.Context, fd *feed, updates chan *update) (re
 		return false, 0
 	}
 
-	if err := f.updateFeedState(ctx, fd.url, func(state *state.Feed, hasState bool) bool {
-		f.updateFeedStateFromHeaders(state, res)
-		f.enqueueFeedItems(fd, state, hasState, parsedFeed.Items, updates)
-		state.MarkFetchSuccess(time.Now())
-		return true
-	}); err != nil {
-		f.handleFetchFailure(ctx, fd.url, err)
-		return false, 0
-	}
+	f.updateFeedStateFromHeaders(fdState, res)
+	f.enqueueFeedItems(fd, fdState, exists, parsedFeed.Items, updates)
+	fdState.MarkFetchSuccess(time.Now())
 	f.markFetchSuccess(fd.url, len(parsedFeed.Items), startTime)
 
 	return false, 0
@@ -259,7 +241,7 @@ func (f *fetcher) logFeedResponse(fd *feed, res *http.Response) {
 	)
 }
 
-func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *feed) (feedStatusResult, error) {
+func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *feed, fdState *state.Feed) (feedStatusResult, error) {
 	// Ignore unmodified feeds and report an error otherwise.
 	if res.StatusCode == http.StatusNotModified {
 		f.slog.Debug("unmodified feed", "feed", fd.url)
@@ -268,10 +250,7 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 			s.HTTP3xxCount += 1
 			s.FeedStats(fd.url).LastStatusClass = 3
 		})
-		_ = f.updateFeedState(req.Context(), fd.url, func(state *state.Feed, _ bool) bool {
-			state.MarkNotModified(time.Now())
-			return true
-		})
+		fdState.MarkNotModified(time.Now())
 		return feedStatusResult{
 			handled: true,
 		}, nil
@@ -664,13 +643,9 @@ func (f *fetcher) handleFetchFailure(ctx context.Context, url string, err error)
 		disabled   bool
 		errorCount int
 	)
-	if updateErr := f.updateFeedState(ctx, url, func(state *state.Feed, _ bool) bool {
-		disabled = state.MarkFetchFailure(err, errorThreshold)
-		errorCount = state.ErrorCount
-		return true
-	}); updateErr != nil {
-		f.slog.Warn("failed to persist feed failure state", "feed", url, "error", updateErr)
-	}
+	state, _ := f.feedState(url)
+	disabled = state.MarkFetchFailure(err, errorThreshold)
+	errorCount = state.ErrorCount
 
 	f.slog.Debug("fetch failed", "feed", url, "error", err)
 
@@ -679,12 +654,7 @@ func (f *fetcher) handleFetchFailure(ctx context.Context, url string, err error)
 		if err := f.errNotify(ctx, err); err != nil {
 			f.slog.Warn("failed to send error notification", "error", err)
 		} else {
-			if updateErr := f.updateFeedState(ctx, url, func(state *state.Feed, _ bool) bool {
-				state.DisabledNotifyPending = false
-				return true
-			}); updateErr != nil {
-				f.slog.Warn("failed to persist feed failure state (DisabledNotifyPending)", "feed", url, "error", updateErr)
-			}
+			state.DisabledNotifyPending = false
 		}
 	}
 }

--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -637,7 +637,7 @@ func TestHandleFeedStatus(t *testing.T) {
 				rec.WriteString(tc.body)
 			}
 
-			result, err := f.handleFeedStatus(req, rec.Result(), fd)
+			result, err := f.handleFeedStatus(req, rec.Result(), fd, &st)
 
 			if tc.wantErrContains != "" {
 				if err == nil {

--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -54,6 +54,8 @@ var (
 	errNoEditor       = errors.New("environment variable EDITOR is not defined")
 )
 
+const finalStateSaveTimeout = 30 * time.Second
+
 // Entry point and program state.
 
 func main() { cli.Main(new(fetcher)) }
@@ -235,12 +237,8 @@ func (f *fetcher) run(ctx context.Context) error {
 			if nErr := f.errNotify(ctx, err); nErr != nil {
 				f.slog.Warn("failed to send pending error notification", "feed", feed.url, "error", nErr)
 			} else {
-				if updateErr := f.updateFeedState(ctx, feed.url, func(state *state.Feed, _ bool) bool {
-					state.DisabledNotifyPending = false
-					return true
-				}); updateErr != nil {
-					f.slog.Warn("failed to persist feed failure state (DisabledNotifyPending)", "feed", feed.url, "error", updateErr)
-				}
+				fdState, _ := f.feedState(feed.url)
+				fdState.DisabledNotifyPending = false
 			}
 		}
 	}
@@ -256,6 +254,8 @@ func (f *fetcher) run(ctx context.Context) error {
 	fetchWg.Wait()
 	close(updates)
 	baseWg.Wait()
+
+	f.cleanState()
 
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
@@ -307,14 +307,16 @@ func (f *fetcher) run(ctx context.Context) error {
 		s.MemoryUsage = m.Alloc
 	})
 
-	if err := f.cleanState(ctx); err != nil {
-		return err
-	}
-
 	f.slog.Debug("fetch finished", "fetched_count", fetchedFeeds.Load(), "all_count", len(f.feeds))
 
 	if f.dry {
 		return nil
+	}
+
+	saveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), finalStateSaveTimeout)
+	defer cancel()
+	if err := f.saveFeedState(saveCtx); err != nil {
+		return fmt.Errorf("saving state failed: %w", err)
 	}
 
 	f.stats.ReadAccess(func(s *stats.Run) {
@@ -379,12 +381,12 @@ func (f *fetcher) retryFeedFetch(ctx context.Context, fd *feed, retries int, ret
 	return ctxsleep.Sleep(ctx, retryIn)
 }
 
-func (f *fetcher) cleanState(ctx context.Context) error {
+func (f *fetcher) cleanState() {
 	keep := make(map[string]struct{}, len(f.feeds))
 	for _, fd := range f.feeds {
 		keep[fd.url] = struct{}{}
 	}
-	return f.pruneFeedState(ctx, keep)
+	f.pruneFeedState(keep)
 }
 
 // User-facing commands.
@@ -515,10 +517,9 @@ func (f *fetcher) reenable(ctx context.Context, url string) error {
 		return fmt.Errorf("%q: %w", url, errNoFeed)
 	}
 
-	return f.updateFeedState(ctx, url, func(fdState *state.Feed, _ bool) bool {
-		fdState.Reenable()
-		return true
-	})
+	fdState, _ := f.feedState(url)
+	fdState.Reenable()
+	return f.saveFeedState(ctx)
 }
 
 // Low-level helpers.

--- a/cmd/tgfeed/state.go
+++ b/cmd/tgfeed/state.go
@@ -181,8 +181,10 @@ func (f *fetcher) loadConfig(ctx context.Context, config string) error {
 	return nil
 }
 
-func (f *fetcher) updateFeedState(ctx context.Context, url string, fn func(*state.Feed, bool) bool) error {
+func (f *fetcher) feedState(url string) (*state.Feed, bool) {
 	f.stateMu.Lock()
+	defer f.stateMu.Unlock()
+
 	if f.state == nil {
 		f.state = map[string]*state.Feed{}
 	}
@@ -191,17 +193,7 @@ func (f *fetcher) updateFeedState(ctx context.Context, url string, fn func(*stat
 		fd = state.NewFeed(time.Now())
 		f.state[url] = fd
 	}
-
-	changed := fn(fd, exists)
-	if !changed {
-		f.stateMu.Unlock()
-		return nil
-	}
-
-	snapshot := cloneFeedStateMap(f.state)
-	f.stateMu.Unlock()
-
-	return f.store.SaveState(ctx, snapshot)
+	return fd, exists
 }
 
 func (f *fetcher) getFeedState(url string) (*state.Feed, bool) {
@@ -221,6 +213,10 @@ func (f *fetcher) feedStateSnapshot() map[string]*state.Feed {
 	return cloneFeedStateMap(f.state)
 }
 
+func (f *fetcher) saveFeedState(ctx context.Context) error {
+	return f.store.SaveState(ctx, f.feedStateSnapshot())
+}
+
 func cloneFeedStateMap(input map[string]*state.Feed) map[string]*state.Feed {
 	out := make(map[string]*state.Feed, len(input))
 	for k, v := range input {
@@ -229,25 +225,16 @@ func cloneFeedStateMap(input map[string]*state.Feed) map[string]*state.Feed {
 	return out
 }
 
-func (f *fetcher) pruneFeedState(ctx context.Context, keep map[string]struct{}) error {
+func (f *fetcher) pruneFeedState(keep map[string]struct{}) {
 	f.stateMu.Lock()
-	changed := false
+	defer f.stateMu.Unlock()
+
 	for url := range f.state {
 		if _, ok := keep[url]; ok {
 			continue
 		}
 		delete(f.state, url)
-		changed = true
 	}
-	if !changed {
-		f.stateMu.Unlock()
-		return nil
-	}
-
-	snapshot := cloneFeedStateMap(f.state)
-	f.stateMu.Unlock()
-
-	return f.store.SaveState(ctx, snapshot)
 }
 
 // Run locking.

--- a/cmd/tgfeed/state_test.go
+++ b/cmd/tgfeed/state_test.go
@@ -228,30 +228,20 @@ func TestFeedStatePrepareSeenItems(t *testing.T) {
 	}
 }
 
-func TestWithFeedState(t *testing.T) {
+func TestFeedState(t *testing.T) {
 	t.Parallel()
 
 	f := &fetcher{store: state.NewStore(state.Options{StateDir: t.TempDir(), DefaultErrorTemplate: "x"})}
 	f.state = map[string]*state.Feed{}
 
 	const feedURL = "https://example.com/feed.xml"
-	var state1 *state.Feed
-	if err := f.updateFeedState(t.Context(), feedURL, func(state *state.Feed, exists bool) bool {
-		state1 = state
-		testutil.AssertEqual(t, exists, false)
-		testutil.AssertEqual(t, state1.LastUpdated.IsZero(), false)
-		return false
-	}); err != nil {
-		t.Fatal(err)
-	}
+	state1, exists := f.feedState(feedURL)
+	testutil.AssertEqual(t, exists, false)
+	testutil.AssertEqual(t, state1.LastUpdated.IsZero(), false)
 
-	if err := f.updateFeedState(t.Context(), feedURL, func(state2 *state.Feed, exists bool) bool {
-		testutil.AssertEqual(t, exists, true)
-		testutil.AssertEqual(t, state2, state1)
-		return false
-	}); err != nil {
-		t.Fatal(err)
-	}
+	state2, exists := f.feedState(feedURL)
+	testutil.AssertEqual(t, exists, true)
+	testutil.AssertEqual(t, state2, state1)
 }
 
 func TestStateMapJSON(t *testing.T) {


### PR DESCRIPTION
Stack PR 4/7.

Depends on #337.

This removes callback-style state persistence and saves feed state once at the run boundary.

Next: #339