### PR TITLE
cmd/tgfeed: simplify fetch flow

### DIFF
--- a/cmd/tgfeed/fetch.go
+++ b/cmd/tgfeed/fetch.go
@@ -64,63 +64,22 @@ type update struct {
 
 // feedStatusResult describes what a response status handler decided to do next.
 //
-// A status can be fully handled (for example, 304 Not Modified), in which case
-// fetch should stop and return. Some handled statuses also request a retry with
-// backoff information.
+// A zero value means the caller should continue parsing the feed body.
 type feedStatusResult struct {
-	handled bool
-	retry   bool
-	retryIn time.Duration
+	notModified bool
+	retryIn     time.Duration
 }
 
 // feedItemDecision captures both item processing and seen-state updates.
 //
-// selection controls whether the item is processed further. markSeen stores the
-// key that should be recorded in seen-items state immediately.
+// process controls whether the item is processed further. markSeen stores the
+// key that should be recorded in seen-items state immediately. skipReason is
+// reported to stats when process is false.
 type feedItemDecision struct {
-	selection feedItemSelection
-	markSeen  string
-	reason    feedItemSkipReason
+	process    bool
+	markSeen   string
+	skipReason stats.FeedItemDecisionReason
 }
-
-func toDecisionReason(d feedItemDecision) stats.FeedItemDecisionReason {
-	switch d.reason {
-	case feedItemSkipReasonOld:
-		return stats.FeedItemSkipReasonOld
-	case feedItemSkipReasonSeen:
-		return stats.FeedItemSkipReasonSeen
-	default:
-		return stats.FeedItemSkipReasonUnknown
-	}
-}
-
-// enqueueAction determines how an accepted item is emitted to the updates
-// channel.
-type enqueueAction uint8
-
-const (
-	enqueueActionSkip enqueueAction = iota
-	enqueueActionSingle
-	enqueueActionDigest
-)
-
-// feedItemSelection describes whether an item should be skipped, only marked
-// as seen, or processed and potentially sent.
-type feedItemSelection uint8
-
-const (
-	feedItemSelectionSkip feedItemSelection = iota
-	feedItemSelectionMarkSeenOnly
-	feedItemSelectionProcess
-)
-
-type feedItemSkipReason uint8
-
-const (
-	feedItemSkipReasonNone feedItemSkipReason = iota
-	feedItemSkipReasonOld
-	feedItemSkipReasonSeen
-)
 
 // feedItemContext groups immutable fetch-time context used while deciding how
 // to handle a specific parsed item.
@@ -129,7 +88,6 @@ type feedItemContext struct {
 	state       *state.Feed
 	exists      bool
 	justEnabled bool
-	starlarkVal starlark.Value
 }
 
 // fetch fetches one feed and either emits updates, asks caller to retry, or
@@ -178,13 +136,17 @@ func (f *fetcher) fetch(ctx context.Context, fd *feed, updates chan *update) (re
 
 	f.logFeedResponse(fd, res)
 
-	status, err := f.handleFeedStatus(req, res, fd, fdState)
+	status, err := f.handleFeedStatus(req, res, fd)
 	if err != nil {
 		f.handleFetchFailure(ctx, fd.url, err)
 		return false, 0
 	}
-	if status.handled {
-		return status.retry, status.retryIn
+	if status.notModified {
+		fdState.MarkNotModified(time.Now())
+		return false, 0
+	}
+	if status.retryIn > 0 {
+		return true, status.retryIn
 	}
 
 	parsedFeed, err := f.fp.Parse(res.Body)
@@ -241,7 +203,7 @@ func (f *fetcher) logFeedResponse(fd *feed, res *http.Response) {
 	)
 }
 
-func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *feed, fdState *state.Feed) (feedStatusResult, error) {
+func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *feed) (feedStatusResult, error) {
 	// Ignore unmodified feeds and report an error otherwise.
 	if res.StatusCode == http.StatusNotModified {
 		f.slog.Debug("unmodified feed", "feed", fd.url)
@@ -250,9 +212,8 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 			s.HTTP3xxCount += 1
 			s.FeedStats(fd.url).LastStatusClass = 3
 		})
-		fdState.MarkNotModified(time.Now())
 		return feedStatusResult{
-			handled: true,
+			notModified: true,
 		}, nil
 	}
 	if res.StatusCode == http.StatusOK {
@@ -274,8 +235,6 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 		if t, found := retry.Retryable(req.URL.Host, body); found {
 			f.slog.Warn("rate-limited", "host", req.URL.Host, "feed", fd.url, "retry_in", t.String())
 			return feedStatusResult{
-				handled: true,
-				retry:   true,
 				retryIn: t,
 			}, nil
 		}
@@ -290,8 +249,6 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 			if t <= maxRetryAfter {
 				f.slog.Warn("rate-limited (Retry-After)", "feed", fd.url, "retry_in", t.String())
 				return feedStatusResult{
-					handled: true,
-					retry:   true,
 					retryIn: t,
 				}, nil
 			}
@@ -302,15 +259,11 @@ func (f *fetcher) handleFeedStatus(req *http.Request, res *http.Response, fd *fe
 	// Retry on generic 5xx server errors without Retry-After header.
 	if res.StatusCode >= 500 && res.StatusCode < 600 {
 		return feedStatusResult{
-			handled: true,
-			retry:   true,
 			retryIn: 5 * time.Second,
 		}, nil
 	}
 
-	return feedStatusResult{
-		handled: true,
-	}, fmt.Errorf("want 200, got %d: %s", res.StatusCode, body)
+	return feedStatusResult{}, fmt.Errorf("want 200, got %d: %s", res.StatusCode, body)
 }
 
 func isTransientError(err error) bool {
@@ -357,38 +310,48 @@ func (f *fetcher) enqueueFeedItems(fd *feed, state *state.Feed, exists bool, ite
 		if decision.markSeen != "" {
 			state.MarkSeen(decision.markSeen, time.Now())
 		}
-		if decision.selection != feedItemSelectionProcess {
+		if !decision.process {
 			f.stats.WriteAccess(func(s *stats.Run) {
-				s.RecordItemDecision(toDecisionReason(decision))
+				s.RecordItemDecision(decision.skipReason)
 			})
 			continue
 		}
 
-		itemCtx.starlarkVal = f.itemToStarlark(feedItem)
-
-		switch f.decideEnqueueAction(itemCtx, feedItem) {
-		case enqueueActionSkip:
+		starlarkVal := f.itemToStarlark(feedItem)
+		if !f.feedItemPassesRules(fd, feedItem, starlarkVal) {
 			continue
-		case enqueueActionDigest:
+		}
+
+		if fd.digest {
 			validItems = append(validItems, feedItem)
-			f.stats.WriteAccess(func(s *stats.Run) {
-				s.ItemsKeptTotal += 1
-				s.ItemsEnqueuedTotal += 1
-				s.FeedStats(fd.url).ItemsEnqueued += 1
-			})
-		case enqueueActionSingle:
-			updates <- &update{
-				feed:  fd,
-				items: []*gofeed.Item{feedItem},
-			}
-			f.stats.WriteAccess(func(s *stats.Run) {
-				s.ItemsKeptTotal += 1
-				s.ItemsEnqueuedTotal += 1
-				s.FeedStats(fd.url).ItemsEnqueued += 1
-			})
+			f.recordItemEnqueued(fd.url)
+			continue
+		}
+
+		f.recordItemEnqueued(fd.url)
+		updates <- &update{
+			feed:  fd,
+			items: []*gofeed.Item{feedItem},
 		}
 	}
 	publishDigestUpdate(fd, validItems, updates)
+}
+
+func (f *fetcher) recordItemEnqueued(feedURL string) {
+	f.stats.WriteAccess(func(s *stats.Run) {
+		s.ItemsKeptTotal += 1
+		s.ItemsEnqueuedTotal += 1
+		s.FeedStats(feedURL).ItemsEnqueued += 1
+	})
+}
+
+func publishDigestUpdate(fd *feed, validItems []*gofeed.Item, updates chan *update) {
+	if len(validItems) > 0 {
+		updates <- &update{
+			feed:  fd,
+			items: validItems,
+		}
+	}
 }
 
 func (f *fetcher) prepareSeenItemsState(fd *feed, state *state.Feed) (justEnabled bool) {
@@ -423,43 +386,33 @@ func decideFeedItem(itemCtx feedItemContext, feedItem *gofeed.Item) feedItemDeci
 		itemDate := feedItemPublishedTime(feedItem)
 		now := time.Now()
 		if itemDate != nil && now.Sub(*itemDate) > lookbackPeriod {
-			return feedItemDecision{selection: feedItemSelectionSkip, reason: feedItemSkipReasonOld}
+			return feedItemDecision{skipReason: stats.FeedItemSkipReasonOld}
 		}
 		if itemCtx.state.IsSeen(guid) {
-			return feedItemDecision{selection: feedItemSelectionSkip, reason: feedItemSkipReasonSeen}
+			return feedItemDecision{skipReason: stats.FeedItemSkipReasonSeen}
 		}
-		decision := feedItemDecision{selection: feedItemSelectionMarkSeenOnly, markSeen: guid}
+		decision := feedItemDecision{markSeen: guid}
 		if !itemCtx.exists || itemCtx.justEnabled {
 			return decision
 		}
-		decision.selection = feedItemSelectionProcess
+		decision.process = true
 		return decision
 	}
 
 	if itemCtx.state.IsSeen(guid) {
-		return feedItemDecision{selection: feedItemSelectionSkip, reason: feedItemSkipReasonSeen}
+		return feedItemDecision{skipReason: stats.FeedItemSkipReasonSeen}
 	}
 
 	itemDate := feedItemActivityTime(feedItem)
 	if itemDate != nil && itemDate.Before(itemCtx.state.LastUpdated) {
-		return feedItemDecision{selection: feedItemSelectionSkip, reason: feedItemSkipReasonOld}
+		return feedItemDecision{skipReason: stats.FeedItemSkipReasonOld}
 	}
 
 	if itemDate == nil && !itemCtx.exists {
-		return feedItemDecision{selection: feedItemSelectionMarkSeenOnly, markSeen: guid}
+		return feedItemDecision{markSeen: guid}
 	}
 
-	return feedItemDecision{selection: feedItemSelectionProcess, markSeen: guid}
-}
-
-func (f *fetcher) decideEnqueueAction(itemCtx feedItemContext, feedItem *gofeed.Item) enqueueAction {
-	if !f.feedItemPassesRules(itemCtx.feed, feedItem, itemCtx.starlarkVal) {
-		return enqueueActionSkip
-	}
-	if itemCtx.feed.digest {
-		return enqueueActionDigest
-	}
-	return enqueueActionSingle
+	return feedItemDecision{process: true, markSeen: guid}
 }
 
 func (f *fetcher) applyRule(rule *starlark.Function, item *gofeed.Item, starlarkVal starlark.Value) bool {
@@ -510,17 +463,6 @@ func (f *fetcher) feedItemPassesRules(fd *feed, feedItem *gofeed.Item, starlarkV
 	}
 
 	return true
-}
-
-func publishDigestUpdate(fd *feed, validItems []*gofeed.Item, updates chan *update) {
-	if !fd.digest || len(validItems) == 0 {
-		return
-	}
-
-	updates <- &update{
-		feed:  fd,
-		items: validItems,
-	}
 }
 
 func (f *fetcher) markFetchSuccess(url string, parsedItems int, startTime time.Time) {

--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -341,13 +341,14 @@ func TestDecideFeedItem(t *testing.T) {
 	old := now.Add(-15 * 24 * time.Hour)
 
 	cases := map[string]struct {
-		fd            *feed
-		state         *state.Feed
-		item          *gofeed.Item
-		exists        bool
-		justEnabled   bool
-		wantSelection feedItemSelection
-		wantMarkSeen  string
+		fd           *feed
+		state        *state.Feed
+		item         *gofeed.Item
+		exists       bool
+		justEnabled  bool
+		wantProcess  bool
+		wantMarkSeen string
+		wantSkip     tgstats.FeedItemDecisionReason
 	}{
 		"always_send_new_items skips old entries": {
 			fd: &feed{
@@ -359,10 +360,11 @@ func TestDecideFeedItem(t *testing.T) {
 				Link:            "https://example.com/old",
 				PublishedParsed: &old,
 			},
-			exists:        true,
-			justEnabled:   false,
-			wantSelection: feedItemSelectionSkip,
-			wantMarkSeen:  "",
+			exists:       true,
+			justEnabled:  false,
+			wantProcess:  false,
+			wantMarkSeen: "",
+			wantSkip:     tgstats.FeedItemSkipReasonOld,
 		},
 		"always_send_new_items prefers published over updated for lookback": {
 			fd: &feed{
@@ -375,10 +377,11 @@ func TestDecideFeedItem(t *testing.T) {
 				PublishedParsed: &old,
 				UpdatedParsed:   &recent,
 			},
-			exists:        true,
-			justEnabled:   false,
-			wantSelection: feedItemSelectionSkip,
-			wantMarkSeen:  "",
+			exists:       true,
+			justEnabled:  false,
+			wantProcess:  false,
+			wantMarkSeen: "",
+			wantSkip:     tgstats.FeedItemSkipReasonOld,
 		},
 		"always_send_new_items falls back to updated when published is missing": {
 			fd: &feed{
@@ -390,10 +393,10 @@ func TestDecideFeedItem(t *testing.T) {
 				Link:          "https://example.com/updated-only",
 				UpdatedParsed: &recent,
 			},
-			exists:        true,
-			justEnabled:   false,
-			wantSelection: feedItemSelectionProcess,
-			wantMarkSeen:  "updated-only",
+			exists:       true,
+			justEnabled:  false,
+			wantProcess:  true,
+			wantMarkSeen: "updated-only",
 		},
 		"always_send_new_items includes new entry for existing feed": {
 			fd: &feed{
@@ -405,10 +408,10 @@ func TestDecideFeedItem(t *testing.T) {
 				Link:            "https://example.com/new",
 				PublishedParsed: &recent,
 			},
-			exists:        true,
-			justEnabled:   false,
-			wantSelection: feedItemSelectionProcess,
-			wantMarkSeen:  "new",
+			exists:       true,
+			justEnabled:  false,
+			wantProcess:  true,
+			wantMarkSeen: "new",
 		},
 		"always_send_new_items suppresses first run": {
 			fd: &feed{
@@ -420,10 +423,11 @@ func TestDecideFeedItem(t *testing.T) {
 				Link:            "https://example.com/first",
 				PublishedParsed: &recent,
 			},
-			exists:        false,
-			justEnabled:   false,
-			wantSelection: feedItemSelectionMarkSeenOnly,
-			wantMarkSeen:  "first",
+			exists:       false,
+			justEnabled:  false,
+			wantProcess:  false,
+			wantMarkSeen: "first",
+			wantSkip:     tgstats.FeedItemSkipReasonUnknown,
 		},
 		"always_send_new_items skips already seen": {
 			fd: &feed{
@@ -437,10 +441,11 @@ func TestDecideFeedItem(t *testing.T) {
 				Link:            "https://example.com/seen",
 				PublishedParsed: &recent,
 			},
-			exists:        true,
-			justEnabled:   false,
-			wantSelection: feedItemSelectionSkip,
-			wantMarkSeen:  "",
+			exists:       true,
+			justEnabled:  false,
+			wantProcess:  false,
+			wantMarkSeen: "",
+			wantSkip:     tgstats.FeedItemSkipReasonSeen,
 		},
 		"published before last update is ignored in regular mode": {
 			fd: &feed{},
@@ -452,10 +457,11 @@ func TestDecideFeedItem(t *testing.T) {
 				Link:            "https://example.com/regular-old",
 				PublishedParsed: &recent,
 			},
-			exists:        true,
-			justEnabled:   false,
-			wantSelection: feedItemSelectionSkip,
-			wantMarkSeen:  "",
+			exists:       true,
+			justEnabled:  false,
+			wantProcess:  false,
+			wantMarkSeen: "",
+			wantSkip:     tgstats.FeedItemSkipReasonOld,
 		},
 		"nil published timestamp is accepted in regular mode": {
 			fd: &feed{},
@@ -466,10 +472,10 @@ func TestDecideFeedItem(t *testing.T) {
 				GUID: "regular-nil",
 				Link: "https://example.com/regular-nil",
 			},
-			exists:        true,
-			justEnabled:   false,
-			wantSelection: feedItemSelectionProcess,
-			wantMarkSeen:  "regular-nil",
+			exists:       true,
+			justEnabled:  false,
+			wantProcess:  true,
+			wantMarkSeen: "regular-nil",
 		},
 	}
 
@@ -483,14 +489,15 @@ func TestDecideFeedItem(t *testing.T) {
 				justEnabled: tc.justEnabled,
 			}
 			decision := decideFeedItem(itemCtx, tc.item)
-			testutil.AssertEqual(t, decision.selection, tc.wantSelection)
+			testutil.AssertEqual(t, decision.process, tc.wantProcess)
 			testutil.AssertEqual(t, decision.markSeen, tc.wantMarkSeen)
+			testutil.AssertEqual(t, decision.skipReason, tc.wantSkip)
 			testutil.AssertEqual(t, len(tc.state.SeenItems), beforeSeenCount)
 		})
 	}
 }
 
-func TestDecideEnqueueAction(t *testing.T) {
+func TestFeedItemPassesRules(t *testing.T) {
 	t.Parallel()
 
 	makeRule := func(t *testing.T, src string, name string) *starlark.Function {
@@ -513,17 +520,12 @@ func TestDecideEnqueueAction(t *testing.T) {
 	cases := map[string]struct {
 		fd   *feed
 		item *gofeed.Item
-		want enqueueAction
+		want bool
 	}{
-		"single action for non-digest feed": {
+		"passes without rules": {
 			fd:   &feed{digest: false},
 			item: &gofeed.Item{Link: "https://example.com/a"},
-			want: enqueueActionSingle,
-		},
-		"digest action for digest feed": {
-			fd:   &feed{digest: true},
-			item: &gofeed.Item{Link: "https://example.com/a"},
-			want: enqueueActionDigest,
+			want: true,
 		},
 		"skip when blocked": {
 			fd: &feed{
@@ -531,7 +533,7 @@ func TestDecideEnqueueAction(t *testing.T) {
 				blockRule: makeRule(t, "def rule(item):\n  return True\n", "rule"),
 			},
 			item: &gofeed.Item{Link: "https://example.com/a"},
-			want: enqueueActionSkip,
+			want: false,
 		},
 		"skip when keep rule rejects": {
 			fd: &feed{
@@ -539,14 +541,14 @@ func TestDecideEnqueueAction(t *testing.T) {
 				keepRule: makeRule(t, "def rule(item):\n  return False\n", "rule"),
 			},
 			item: &gofeed.Item{Link: "https://example.com/a"},
-			want: enqueueActionSkip,
+			want: false,
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			f := newTestFetcher(t, newTestEnv(t, nil, nil))
-			got := f.decideEnqueueAction(feedItemContext{feed: tc.fd}, tc.item)
+			got := f.feedItemPassesRules(tc.fd, tc.item, f.itemToStarlark(tc.item))
 			testutil.AssertEqual(t, got, tc.want)
 		})
 	}
@@ -556,18 +558,14 @@ func TestHandleFeedStatus(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
-		reqURL                 string
-		statusCode             int
-		body                   string
-		initialState           state.Feed
-		wantHandled            bool
-		wantRetry              bool
-		wantRetryIn            time.Duration
-		wantErrContains        string
-		wantErrorCount         int
-		wantLastError          string
-		wantLastUpdatedNonZero bool
-		wantNotModifiedFeeds   int
+		reqURL               string
+		statusCode           int
+		body                 string
+		initialState         state.Feed
+		wantNotModified      bool
+		wantRetryIn          time.Duration
+		wantErrContains      string
+		wantNotModifiedFeeds int
 	}{
 		"not modified": {
 			reqURL:     "https://example.com/feed.xml",
@@ -576,43 +574,30 @@ func TestHandleFeedStatus(t *testing.T) {
 				ErrorCount: 3,
 				LastError:  "oops",
 			},
-			wantHandled:            true,
-			wantRetry:              false,
-			wantRetryIn:            0,
-			wantErrorCount:         0,
-			wantLastError:          "",
-			wantLastUpdatedNonZero: true,
-			wantNotModifiedFeeds:   1,
+			wantNotModified:      true,
+			wantRetryIn:          0,
+			wantNotModifiedFeeds: 1,
 		},
 		"200 status": {
-			reqURL:         "https://example.com/feed.xml",
-			statusCode:     http.StatusOK,
-			wantHandled:    false,
-			wantRetry:      false,
-			wantRetryIn:    0,
-			wantErrorCount: 0,
-			wantLastError:  "",
+			reqURL:          "https://example.com/feed.xml",
+			statusCode:      http.StatusOK,
+			wantNotModified: false,
+			wantRetryIn:     0,
 		},
 		"tg.i-c-a.su retry": {
-			reqURL:         "https://tg.i-c-a.su/feed.json",
-			statusCode:     http.StatusTooManyRequests,
-			body:           `{"errors":["FLOOD_WAIT_15"]}`,
-			wantHandled:    true,
-			wantRetry:      true,
-			wantRetryIn:    15 * time.Second,
-			wantErrorCount: 0,
-			wantLastError:  "",
+			reqURL:          "https://tg.i-c-a.su/feed.json",
+			statusCode:      http.StatusTooManyRequests,
+			body:            `{"errors":["FLOOD_WAIT_15"]}`,
+			wantNotModified: false,
+			wantRetryIn:     15 * time.Second,
 		},
 		"non-200 returns error": {
 			reqURL:          "https://example.com/feed.xml",
 			statusCode:      http.StatusTeapot,
 			body:            "teapot",
-			wantHandled:     true,
-			wantRetry:       false,
+			wantNotModified: false,
 			wantRetryIn:     0,
 			wantErrContains: "want 200, got 418: teapot",
-			wantErrorCount:  0,
-			wantLastError:   "",
 		},
 	}
 
@@ -637,7 +622,7 @@ func TestHandleFeedStatus(t *testing.T) {
 				rec.WriteString(tc.body)
 			}
 
-			result, err := f.handleFeedStatus(req, rec.Result(), fd, &st)
+			result, err := f.handleFeedStatus(req, rec.Result(), fd)
 
 			if tc.wantErrContains != "" {
 				if err == nil {
@@ -650,12 +635,9 @@ func TestHandleFeedStatus(t *testing.T) {
 				testutil.AssertEqual(t, err, nil)
 			}
 
-			testutil.AssertEqual(t, result.handled, tc.wantHandled)
-			testutil.AssertEqual(t, result.retry, tc.wantRetry)
+			testutil.AssertEqual(t, result.notModified, tc.wantNotModified)
 			testutil.AssertEqual(t, result.retryIn, tc.wantRetryIn)
-			testutil.AssertEqual(t, st.ErrorCount, tc.wantErrorCount)
-			testutil.AssertEqual(t, st.LastError, tc.wantLastError)
-			testutil.AssertEqual(t, !st.LastUpdated.IsZero(), tc.wantLastUpdatedNonZero)
+			testutil.AssertEqual(t, st, tc.initialState)
 
 			f.stats.ReadAccess(func(s *tgstats.Run) {
 				testutil.AssertEqual(t, s.NotModifiedFeeds, tc.wantNotModifiedFeeds)


### PR DESCRIPTION
Stack PR 5/7.

Depends on #338.

This folds down fetch item/status decision plumbing so the fetch path reads more directly.

Next: #340