### PR TITLE
cmd: use os.Root for path-confined file access

### DIFF
--- a/cmd/audiorenamer/main.go
+++ b/cmd/audiorenamer/main.go
@@ -64,6 +64,12 @@ func (a *app) Run(ctx context.Context) error {
 		dir = realdir
 	}
 
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
 	// Drop privileges if not inside tests.
 	restrict.DoUnlessTesting(ctx, landlock.RWDirs(dir))
 
@@ -75,7 +81,7 @@ func (a *app) Run(ctx context.Context) error {
 
 	var processed, existing, renamed int
 
-	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	if err := fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -83,7 +89,7 @@ func (a *app) Run(ctx context.Context) error {
 			return nil
 		}
 
-		f, err := os.Open(path)
+		f, err := root.Open(filepath.FromSlash(path))
 		if err != nil {
 			return err
 		}
@@ -103,15 +109,15 @@ func (a *app) Run(ctx context.Context) error {
 
 		processed++
 
-		dir := filepath.Dir(path)
+		reldir := filepath.Dir(filepath.FromSlash(path))
 
 		var buf bytes.Buffer
 		if err := tmpl.Execute(&buf, m); err != nil {
 			return err
 		}
 		// Strip slashes from the new name to make it a valid filename.
-		newname := strings.ReplaceAll(buf.String(), "/", "")
-		newname = filepath.Join(dir, newname+filepath.Ext(path))
+		newname := strings.NewReplacer("/", "", "\\", "").Replace(buf.String())
+		newname = filepath.Join(reldir, newname+filepath.Ext(path))
 
 		if path == newname {
 			vlog("already exists, no need to rename", slog.String("path", path))
@@ -125,7 +131,7 @@ func (a *app) Run(ctx context.Context) error {
 		}
 		vlog(logMsg, slog.String("from", path), slog.String("to", newname))
 		if !a.dry {
-			if err := os.Rename(path, newname); err != nil {
+			if err := root.Rename(filepath.FromSlash(path), newname); err != nil {
 				return err
 			}
 		}

--- a/cmd/dupfind/main.go
+++ b/cmd/dupfind/main.go
@@ -54,12 +54,18 @@ type dup struct {
 }
 
 func lookup(dir string) ([]dup, error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
 	var (
 		dups   []dup
 		hashes = make(map[string]string)
 	)
 
-	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	if err := fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -68,7 +74,7 @@ func lookup(dir string) ([]dup, error) {
 			return nil
 		}
 
-		f, err := os.Open(path)
+		f, err := root.Open(filepath.FromSlash(path))
 		if err != nil {
 			return err
 		}
@@ -83,18 +89,9 @@ func lookup(dir string) ([]dup, error) {
 
 		prev, hasDup := hashes[hh]
 		if hasDup {
-			bpath, err := filepath.Rel(dir, path)
-			if err != nil {
-				return err
-			}
-			bprev, err := filepath.Rel(dir, prev)
-			if err != nil {
-				return err
-			}
-
 			dups = append(dups, dup{
-				cur:  bpath,
-				prev: bprev,
+				cur:  filepath.FromSlash(path),
+				prev: filepath.FromSlash(prev),
 			})
 			return nil
 		}

--- a/cmd/mdserve/main.go
+++ b/cmd/mdserve/main.go
@@ -52,6 +52,9 @@ type engine struct {
 	// configuration
 	addr string
 	fs   fs.FS
+	root *os.Root
+
+	initErr error
 
 	// used in tests
 	noServerStart bool
@@ -79,6 +82,7 @@ func (e *engine) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		e.root = root
 		e.fs = root.FS()
 		rules = append(rules, landlock.RODirs(dir))
 	}
@@ -101,6 +105,9 @@ func (e *engine) Run(ctx context.Context) error {
 	restrict.DoUnlessTesting(ctx, rules...)
 
 	e.init.Do(e.doInit)
+	if e.initErr != nil {
+		return e.initErr
+	}
 
 	if dir != "" {
 		logger.Info(ctx, "serving from", slog.String("dir", dir))
@@ -116,7 +123,13 @@ func (e *engine) Run(ctx context.Context) error {
 func (e *engine) doInit() {
 	// Serve by default from current directory.
 	if e.fs == nil {
-		e.fs = os.DirFS(".")
+		root, err := os.OpenRoot(".")
+		if err != nil {
+			e.initErr = err
+			return
+		}
+		e.root = root
+		e.fs = root.FS()
 	}
 	e.md = &markdown.Parser{
 		HeadingID:          true,
@@ -142,6 +155,10 @@ func (e *engine) doInit() {
 
 func (e *engine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	e.init.Do(e.doInit)
+	if e.initErr != nil {
+		web.RespondError(w, r, e.initErr)
+		return
+	}
 
 	p := r.URL.Path
 	if p == "/" {

--- a/cmd/renamer/main.go
+++ b/cmd/renamer/main.go
@@ -50,10 +50,16 @@ func (a *app) Run(ctx context.Context) error {
 		dir = realdir
 	}
 
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
 	// Drop privileges if not in tests.
 	restrict.DoUnlessTesting(ctx, landlock.RWDirs(dir))
 
-	files, err := os.ReadDir(dir)
+	files, err := fs.ReadDir(root.FS(), ".")
 	if err != nil {
 		return err
 	}
@@ -90,32 +96,34 @@ func (a *app) Run(ctx context.Context) error {
 		return errUnknownSortMode
 	}
 
-	return a.rename(ctx, dir, files)
+	return a.rename(ctx, root, dir, files)
 }
 
-func (a *app) rename(ctx context.Context, dir string, files []fs.DirEntry) error {
+func (a *app) rename(ctx context.Context, root *os.Root, dir string, files []fs.DirEntry) error {
 	for _, d := range files {
 		if d.IsDir() {
 			return nil
 		}
 
 		var (
-			ext     = filepath.Ext(d.Name())
-			oldname = filepath.Join(dir, d.Name())
-			newname = filepath.Join(dir, fmt.Sprintf("%d%s", a.start, ext))
+			ext        = filepath.Ext(d.Name())
+			oldname    = d.Name()
+			newname    = fmt.Sprintf("%d%s", a.start, ext)
+			oldLogPath = filepath.Join(dir, oldname)
+			newLogPath = filepath.Join(dir, newname)
 		)
 
-		if _, err := os.Stat(newname); !errors.Is(err, fs.ErrNotExist) {
-			logger.Info(ctx, "file already exists, skipping", slog.String("path", newname))
+		if _, err := root.Stat(newname); !errors.Is(err, fs.ErrNotExist) {
+			logger.Info(ctx, "file already exists, skipping", slog.String("path", newLogPath))
 			a.start++
 			continue
 		}
 
 		if a.dry {
-			logger.Info(ctx, "would rename", slog.String("from", oldname), slog.String("to", newname))
+			logger.Info(ctx, "would rename", slog.String("from", oldLogPath), slog.String("to", newLogPath))
 		} else {
-			logger.Info(ctx, "renaming", slog.String("from", oldname), slog.String("to", newname))
-			if err := os.Rename(oldname, newname); err != nil {
+			logger.Info(ctx, "renaming", slog.String("from", oldLogPath), slog.String("to", newLogPath))
+			if err := root.Rename(oldname, newname); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Migrate audiorenamer, dupfind, mdserve, and renamer to perform filesystem operations through os.Root so user-provided directory roots remain path-confined.

audiorenamer now walks the root FS, opens files through Root.Open, and renames with Root.Rename. Generated names continue to be relative to the walked directory and now strip both Unix and Windows path separators before renaming.

dupfind now opens the scan directory as an os.Root, walks root.FS, and reads files through Root.Open while preserving duplicate output as root-relative paths.

mdserve already used os.OpenRoot for explicit directories; this also replaces the default os.DirFS current-directory fallback with an os.Root-backed FS and reports initialization failures cleanly.

renamer now reads directory entries from root.FS, checks destination existence with Root.Stat, and performs renames with Root.Rename while keeping log output as full user-facing paths.

This reduces path traversal exposure from symlinks or crafted relative paths by routing file access through the Go standard library's root-confined APIs.
