### PR TITLE
cmd/starlet: add llm module

### DIFF
--- a/cmd/starlet/doc.go
+++ b/cmd/starlet/doc.go
@@ -72,6 +72,11 @@ Optional:
 
   - DATABASE_PATH: Path to a SQLite database file. If not provided, an in-memory store is used.
   - GEMINI_KEY: API key for Google Gemini (required to use the gemini module).
+  - LLM_API_KEY: API key for an OpenAI-compatible gateway (required to use llm).
+  - LLM_API_URL: API root URL for an OpenAI-compatible gateway, for example
+    https://api.openai.com/v1 (required to use llm).
+  - LLM_USAGE_PATH: Path to persistent JSON file with per-key token usage stats
+    for llm module. Defaults to llm-usage.json in current directory.
   - GH_TOKEN: A GitHub Personal Access Token (PAT) with gist scope. Recommended for higher rate limits.
 
 # Admin Interface

--- a/cmd/starlet/internal/bot/bot.go
+++ b/cmd/starlet/internal/bot/bot.go
@@ -23,6 +23,7 @@ import (
 	"go.astrophena.name/base/version"
 	"go.astrophena.name/base/web"
 	"go.astrophena.name/tools/internal/api/gemini"
+	"go.astrophena.name/tools/internal/api/llm"
 	"go.astrophena.name/tools/internal/starlark/go2star"
 	"go.astrophena.name/tools/internal/starlark/interpreter"
 	"go.astrophena.name/tools/internal/tgmarkup"
@@ -64,11 +65,13 @@ type Bot struct {
 	tgBotID       int64
 	tgBotUsername string
 
-	httpc    *http.Client
-	geminic  *gemini.Client
-	kvCache  *starlarkstruct.Module
-	scrubber *strings.Replacer
-	logger   *slog.Logger
+	httpc        *http.Client
+	geminic      *gemini.Client
+	llmc         *llm.Client
+	llmUsagePath string
+	kvCache      *starlarkstruct.Module
+	scrubber     *strings.Replacer
+	logger       *slog.Logger
 
 	instance atomic.Pointer[instance]
 }
@@ -96,6 +99,10 @@ type Opts struct {
 	HTTPClient *http.Client
 	// GeminiClient is the client for interacting with the Google Gemini API.
 	GeminiClient *gemini.Client
+	// LLMClient is the client for interacting with an OpenAI-compatible LLM API.
+	LLMClient *llm.Client
+	// LLMUsagePath is path to persistent usage stats JSON for llm module.
+	LLMUsagePath string
 	// KVCache is the key-value cache for Starlark.
 	KVCache *starlarkstruct.Module
 	// Scrubber is used to scrub sensitive information from logs.
@@ -114,6 +121,8 @@ func New(opts Opts) *Bot {
 		tgBotUsername: opts.BotUsername,
 		httpc:         opts.HTTPClient,
 		geminic:       opts.GeminiClient,
+		llmc:          opts.LLMClient,
+		llmUsagePath:  opts.LLMUsagePath,
 		kvCache:       opts.KVCache,
 		scrubber:      opts.Scrubber,
 		logger:        opts.Logger,

--- a/cmd/starlet/internal/bot/doc.md
+++ b/cmd/starlet/internal/bot/doc.md
@@ -89,6 +89,45 @@ To ask a question about an image:
 The responses variable will contain a list of generated responses, where each response
 is a list of strings representing the parts of the generated content.
 
+## `llm`
+
+LLM provider.
+
+The module sends chat-style contents, optional image bytes, and optional
+instructions to the configured OpenAI Responses-compatible /responses endpoint.
+It returns the response's text output as a single string and records token usage
+under a caller-provided usage key.
+
+This is useful with the OpenAI API and with other AI providers that expose a
+compatible endpoint, such as OpenRouter.
+
+This module provides two functions: generate and usage.
+
+usage(key, date?) returns cumulative token usage for the key.
+If date is provided (YYYY-MM-DD), it returns usage only for that exact UTC day.
+
+generate accepts the following keyword arguments:
+
+  - model (str): Model name to generate with.
+  - contents (list of (str, str) tuples): A list of (role, content) messages.
+  - usage_key (str): Arbitrary key used to accumulate persistent token usage stats.
+  - image (bytes, optional): Optional raw image bytes to upload as input_image.
+  - instructions (str, optional): Optional high-level instructions for the model.
+
+For example:
+
+	text = llm.generate(
+	    model="gpt-4.1-mini",
+	    contents=[
+	        ("user", "Describe this image briefly.")
+	    ],
+	    image=files.read("cat.jpg"),
+	    usage_key="chat:123",
+	    instructions="Be concise."
+	)
+
+The return value is a single string from the response output message text.
+
 ## `kvcache`
 
 This module provides two functions for using a simple key-value cache:

--- a/cmd/starlet/internal/bot/env.go
+++ b/cmd/starlet/internal/bot/env.go
@@ -14,6 +14,7 @@ import (
 	"go.astrophena.name/tools/internal/starlark/gemini"
 	"go.astrophena.name/tools/internal/starlark/go2star"
 	"go.astrophena.name/tools/internal/starlark/kvcache"
+	"go.astrophena.name/tools/internal/starlark/llm"
 	"go.astrophena.name/tools/internal/starlark/telegram"
 	"go.astrophena.name/tools/internal/tgmarkup"
 
@@ -166,6 +167,11 @@ func (b *Bot) environment() Environment {
 			Name:  "gemini",
 			Doc:   gemini.Documentation(),
 			Value: gemini.Module(b.geminic),
+		},
+		{
+			Name:  "llm",
+			Doc:   llm.Documentation(),
+			Value: llm.Module(b.llmc, b.llmUsagePath),
 		},
 		{
 			Name:  "kvcache",

--- a/cmd/starlet/main.go
+++ b/cmd/starlet/main.go
@@ -24,6 +24,7 @@ import (
 	"go.astrophena.name/tools/cmd/starlet/internal/bot"
 	"go.astrophena.name/tools/internal/api/gemini"
 	"go.astrophena.name/tools/internal/api/gist"
+	"go.astrophena.name/tools/internal/api/llm"
 	"go.astrophena.name/tools/internal/starlark/kvcache"
 	"go.astrophena.name/tools/internal/store"
 )
@@ -48,6 +49,9 @@ type engine struct {
 	// configuration, read-only after initialization
 	databasePath string
 	geminiKey    string
+	llmAPIKey    string
+	llmAPIURL    string
+	llmUsagePath string
 	ghToken      string
 	gistID       string
 	host         string
@@ -90,6 +94,9 @@ func (e *engine) doInit(ctx context.Context) error {
 	// Load configuration from environment variables.
 	e.databasePath = cmp.Or(e.databasePath, env.Getenv("DATABASE_PATH"))
 	e.geminiKey = cmp.Or(e.geminiKey, env.Getenv("GEMINI_KEY"))
+	e.llmAPIKey = cmp.Or(e.llmAPIKey, env.Getenv("LLM_API_KEY"))
+	e.llmAPIURL = cmp.Or(e.llmAPIURL, env.Getenv("LLM_API_URL"))
+	e.llmUsagePath = cmp.Or(e.llmUsagePath, env.Getenv("LLM_USAGE_PATH"))
 	e.ghToken = cmp.Or(e.ghToken, env.Getenv("GH_TOKEN"))
 	e.gistID = cmp.Or(e.gistID, env.Getenv("GIST_ID"))
 	e.host = cmp.Or(e.host, env.Getenv("HOST"))
@@ -114,6 +121,7 @@ func (e *engine) doInit(ctx context.Context) error {
 		e.tgSecret,
 		e.tgToken,
 		e.geminiKey,
+		e.llmAPIKey,
 	} {
 		if val != "" {
 			scrubPairs = append(scrubPairs, val, "[EXPUNGED]")
@@ -140,19 +148,33 @@ func (e *engine) doInit(ctx context.Context) error {
 		e.store = store.NewMemStore(ctx, kvCacheTTL)
 	}
 
+	if e.llmUsagePath == "" {
+		e.llmUsagePath = "llm-usage.json"
+	}
+
 	opts := bot.Opts{
-		Token:      e.tgToken,
-		Secret:     e.tgSecret,
-		Owner:      e.tgOwner,
-		HTTPClient: e.httpc,
-		KVCache:    kvcache.Module(ctx, e.store),
-		Scrubber:   e.scrubber,
-		Logger:     e.logger.WithGroup("bot"),
+		Token:        e.tgToken,
+		Secret:       e.tgSecret,
+		Owner:        e.tgOwner,
+		HTTPClient:   e.httpc,
+		KVCache:      kvcache.Module(ctx, e.store),
+		Scrubber:     e.scrubber,
+		Logger:       e.logger.WithGroup("bot"),
+		LLMUsagePath: e.llmUsagePath,
 	}
 
 	if e.geminiKey != "" {
 		opts.GeminiClient = &gemini.Client{
 			APIKey:     e.geminiKey,
+			HTTPClient: e.httpc,
+			Scrubber:   e.scrubber,
+		}
+	}
+
+	if e.llmAPIKey != "" && e.llmAPIURL != "" {
+		opts.LLMClient = &llm.Client{
+			APIKey:     e.llmAPIKey,
+			APIURL:     e.llmAPIURL,
 			HTTPClient: e.httpc,
 			Scrubber:   e.scrubber,
 		}

--- a/internal/api/llm/llm.go
+++ b/internal/api/llm/llm.go
@@ -1,0 +1,133 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package llm provides a minimal client for OpenAI Responses API compatible
+// gateways.
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"go.astrophena.name/base/request"
+	"go.astrophena.name/base/version"
+)
+
+// Client holds configuration for interacting with an LLM API gateway.
+type Client struct {
+	// APIURL is the API root URL, for example https://api.openai.com/v1.
+	APIURL string
+	// APIKey is the API key used for bearer authentication.
+	APIKey string
+	// HTTPClient is an optional HTTP client to use for requests. Defaults to
+	// request.DefaultClient.
+	HTTPClient *http.Client
+	// Scrubber is an optional strings.Replacer that scrubs unwanted data from
+	// error messages.
+	Scrubber *strings.Replacer
+}
+
+// ContentPart is a single item inside a message content.
+type ContentPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL string `json:"image_url,omitempty"`
+}
+
+// Message is an input message.
+type Message struct {
+	Role    string        `json:"role"`
+	Content []ContentPart `json:"content"`
+}
+
+// ResponseParams defines the request body for POST /responses.
+type ResponseParams struct {
+	Model        string    `json:"model"`
+	Input        []Message `json:"input"`
+	Instructions string    `json:"instructions,omitempty"`
+}
+
+// Response is a subset of the OpenAI Responses API response.
+type Response struct {
+	OutputText string `json:"output_text"`
+	output     []responseOutputItem
+	Usage      struct {
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+type responseOutputItem struct {
+	Type    string                  `json:"type"`
+	Content []responseOutputContent `json:"content"`
+}
+
+type responseOutputContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// UnmarshalJSON fills OutputText from the Responses API output array when the
+// gateway does not provide the SDK-style output_text convenience field.
+func (r *Response) UnmarshalJSON(data []byte) error {
+	type response Response
+	var resp struct {
+		response
+		Output []responseOutputItem `json:"output"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+	*r = Response(resp.response)
+	r.output = resp.Output
+	if r.OutputText == "" {
+		r.OutputText = r.outputText()
+	}
+	return nil
+}
+
+func (r *Response) outputText() string {
+	var b strings.Builder
+	for _, output := range r.output {
+		if output.Type != "" && output.Type != "message" {
+			continue
+		}
+		for _, content := range output.Content {
+			if content.Type != "" && content.Type != "output_text" {
+				continue
+			}
+			b.WriteString(content.Text)
+		}
+	}
+	return b.String()
+}
+
+// CreateResponse sends a POST /responses request.
+func (c *Client) CreateResponse(ctx context.Context, params ResponseParams) (*Response, error) {
+	if c.APIURL == "" {
+		return nil, errors.New("APIURL shouldn't be empty")
+	}
+	if c.APIKey == "" {
+		return nil, errors.New("APIKey shouldn't be empty")
+	}
+	if params.Model == "" {
+		return nil, errors.New("model shouldn't be empty")
+	}
+
+	return request.Make[*Response](ctx, request.Params{
+		Method: http.MethodPost,
+		URL:    strings.TrimRight(c.APIURL, "/") + "/responses",
+		Headers: map[string]string{
+			"Authorization": "Bearer " + c.APIKey,
+			"Content-Type":  "application/json",
+			"User-Agent":    version.UserAgent(),
+		},
+		Body:       params,
+		HTTPClient: c.HTTPClient,
+		Scrubber:   c.Scrubber,
+	})
+}

--- a/internal/api/llm/llm_test.go
+++ b/internal/api/llm/llm_test.go
@@ -1,0 +1,195 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"go.astrophena.name/base/rr"
+	"go.astrophena.name/base/testutil"
+)
+
+// Updating this test:
+//
+//	$  LLM_API_URL=... LLM_API_KEY=... LLM_MODEL=... go test -run TestCreateResponse -httprecord testdata/create_response.httprr
+//
+// For OpenAI, LLM_API_URL is usually https://api.openai.com/v1. For providers
+// such as OpenRouter, use that provider's OpenAI Responses-compatible base URL.
+// LLM_MODEL defaults to gpt-4.1-mini.
+//
+// (notice an extra space before command to prevent recording it in shell
+// history)
+
+func TestCreateResponse(t *testing.T) {
+	recFile := filepath.Join("testdata", "create_response.httprr")
+	recording, err := rr.Recording(recFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recording {
+		if err := os.MkdirAll(filepath.Dir(recFile), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	} else if _, err := os.Stat(recFile); errors.Is(err, os.ErrNotExist) {
+		t.Skipf("%s is not recorded; see update command above", recFile)
+	} else if err != nil {
+		t.Fatal(err)
+	}
+
+	rec, err := rr.Open(recFile, http.DefaultTransport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close()
+	rec.ScrubReq(func(r *http.Request) error {
+		r.Header.Del("Authorization")
+		r.Host = "llm.example"
+		r.URL.Scheme = "https"
+		r.URL.Host = "llm.example"
+		r.URL.Path = "/responses"
+		r.URL.RawQuery = ""
+		r.URL.Fragment = ""
+
+		if r.Body == nil {
+			return nil
+		}
+		body := r.Body.(*rr.Body)
+		var params ResponseParams
+		if err := json.Unmarshal(body.Data, &params); err != nil {
+			return err
+		}
+		params.Model = "test-model"
+		data, err := json.Marshal(params)
+		if err != nil {
+			return err
+		}
+		body.Data = data
+		body.ReadOffset = 0
+		return nil
+	})
+	rec.ScrubResp(func(b *bytes.Buffer) error {
+		resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(b.Bytes())), nil)
+		if err != nil {
+			return err
+		}
+		resp.Header.Del("Server")
+		resp.Header.Del("Set-Cookie")
+
+		data, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return err
+		}
+		data = responseUserRe.ReplaceAll(data, []byte(`"user":"example"`))
+		resp.Body = io.NopCloser(bytes.NewReader(data))
+		resp.ContentLength = int64(len(data))
+
+		b.Reset()
+		return resp.Write(b)
+	})
+
+	apiURL := "https://llm.example/v1"
+	apiKey := "example"
+	model := "gpt-4.1-mini"
+	if rec.Recording() {
+		apiURL = os.Getenv("LLM_API_URL")
+		apiKey = os.Getenv("LLM_API_KEY")
+		model = cmp.Or(os.Getenv("LLM_MODEL"), model)
+		if apiURL == "" {
+			t.Fatal("LLM_API_URL must be set when recording")
+		}
+		if apiKey == "" {
+			t.Fatal("LLM_API_KEY must be set when recording")
+		}
+	}
+
+	c := &Client{
+		APIURL:     apiURL,
+		APIKey:     apiKey,
+		HTTPClient: rec.Client(),
+	}
+
+	resp, err := c.CreateResponse(t.Context(), ResponseParams{
+		Model: model,
+		Input: []Message{{
+			Role:    "user",
+			Content: []ContentPart{{Type: "input_text", Text: "Reply with one short sentence."}},
+		}},
+		Instructions: "Be concise.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(resp.OutputText) == "" {
+		t.Fatal("response output text is empty")
+	}
+	if resp.Usage.InputTokens == 0 {
+		t.Fatal("response input token usage is empty")
+	}
+	if resp.Usage.OutputTokens == 0 {
+		t.Fatal("response output token usage is empty")
+	}
+}
+
+var responseUserRe = regexp.MustCompile(`"user":"[^"]*"`)
+
+func TestResponseOutputText(t *testing.T) {
+	cases := map[string]struct {
+		body string
+		want string
+	}{
+		"output array": {
+			body: `{
+				"output": [
+					{
+						"type": "message",
+						"content": [
+							{"type": "output_text", "text": "hello"},
+							{"type": "output_text", "text": " world"}
+						]
+					}
+				],
+				"usage": {
+					"input_tokens": 12,
+					"output_tokens": 3
+				}
+			}`,
+			want: "hello world",
+		},
+		"output text": {
+			body: `{
+				"output_text": "hello from gateway",
+				"usage": {
+					"input_tokens": 12,
+					"output_tokens": 3
+				}
+			}`,
+			want: "hello from gateway",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var resp Response
+			if err := json.Unmarshal([]byte(tc.body), &resp); err != nil {
+				t.Fatal(err)
+			}
+			testutil.AssertEqual(t, resp.OutputText, tc.want)
+			testutil.AssertEqual(t, resp.Usage.InputTokens, int64(12))
+			testutil.AssertEqual(t, resp.Usage.OutputTokens, int64(3))
+		})
+	}
+}

--- a/internal/api/llm/testdata/create_response.httprr
+++ b/internal/api/llm/testdata/create_response.httprr
@@ -1,0 +1,21 @@
+httprr trace v1
+332 2095
+POST https://llm.example/responses HTTP/1.1
+Host: llm.example
+User-Agent: llm.test/ (+https://astrophena.name/bleep-bloop)
+Content-Length: 151
+Content-Type: application/json
+
+{"model":"test-model","input":[{"role":"user","content":[{"type":"input_text","text":"Reply with one short sentence."}]}],"instructions":"Be concise."}HTTP/2.0 200 OK
+Content-Length: 1792
+Cache-Control: no-cache
+Cache-Control: no-cache, no-store, must-revalidate
+Content-Type: application/json
+Date: Wed, 27 May 2026 16:59:19 GMT
+Expires: 0
+Pragma: no-cache
+X-Accel-Buffering: no
+X-Ratelimit-Reset-Requests: 2ms
+X-Ratelimit-Reset-Tokens: 0s
+
+{"id":"resp_cGsAflnzPi-ic1fuAUaZbYupCjDoUK2iLocVdPitUropiKA-b30DDvACNkTMu20Nba5mz4s7TBvSTYqVBiCHiwYPEmbf_eMzpQ78YV3E5FXZsVjNKgnqmZ8DJYuiaVNptX6rkGraRC4-M4X0_trqKCzrxXGXJfXMtdfoYyc5Zo4eWUxmL6zxiluhGkAVJySn7qmXztPD_9U3HzE471pYJoRlsI-XDO5yWzvChlpUctR9wS-VGt3SdkapaqyoxIf7zbuWN__docyhTLcv4iJz12ya4RrayuFdLR10HtGfp90yK7uO6KknvvoY-44EFJB8Ik5Foyqjbq-QB1y0nOUXV_Aq4x0b3BxcY7ms4wCU59XwYQOcfmKNMozoFWuB_PMwWiautldQilUer4pezSr5yVJIL9ZKpg==","created_at":1779901157,"error":null,"incomplete_details":null,"instructions":"Be concise.","metadata":{},"model":"openai/gpt-5-nano","object":"response","output":[{"id":"rs_0818a2983f7e1a2d006a1722e6172881908380fda02a978937","summary":[],"type":"reasoning"},{"id":"msg_0818a2983f7e1a2d006a1722e7375481909cfcbc073dc29360","content":[{"annotations":[],"text":"Sure, I can help with that.","type":"output_text","logprobs":[]}],"role":"assistant","status":"completed","type":"message","phase":null}],"parallel_tool_calls":true,"temperature":1.0,"tool_choice":"auto","tools":[],"top_p":1.0,"max_output_tokens":null,"previous_response_id":null,"reasoning":{"context":"current_turn","effort":"medium","summary":null},"status":"completed","text":{"format":{"type":"text"},"verbosity":"medium"},"truncation":"disabled","usage":{"input_tokens":19,"input_tokens_details":{"audio_tokens":null,"cached_tokens":0,"text_tokens":null},"output_tokens":183,"output_tokens_details":{"reasoning_tokens":128,"text_tokens":null},"total_tokens":202,"cost":null},"user":"example","store":true,"background":false,"billing":{"payer":"developer"},"completed_at":1779901159,"frequency_penalty":0.0,"max_tool_calls":null,"moderation":null,"presence_penalty":0.0,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","safety_identifier":null,"service_tier":"default","top_logprobs":0}

--- a/internal/starlark/internal/testdata/llm.golden
+++ b/internal/starlark/internal/testdata/llm.golden
@@ -1,0 +1,36 @@
+LLM provider.
+
+The module sends chat-style contents, optional image bytes, and optional
+instructions to the configured OpenAI Responses-compatible /responses endpoint.
+It returns the response's text output as a single string and records token usage
+under a caller-provided usage key.
+
+This is useful with the OpenAI API and with other AI providers that expose a
+compatible endpoint, such as OpenRouter.
+
+This module provides two functions: generate and usage.
+
+usage(key, date?) returns cumulative token usage for the key.
+If date is provided (YYYY-MM-DD), it returns usage only for that exact UTC day.
+
+generate accepts the following keyword arguments:
+
+  - model (str): Model name to generate with.
+  - contents (list of (str, str) tuples): A list of (role, content) messages.
+  - usage_key (str): Arbitrary key used to accumulate persistent token usage stats.
+  - image (bytes, optional): Optional raw image bytes to upload as input_image.
+  - instructions (str, optional): Optional high-level instructions for the model.
+
+For example:
+
+	text = llm.generate(
+	    model="gpt-4.1-mini",
+	    contents=[
+	        ("user", "Describe this image briefly.")
+	    ],
+	    image=files.read("cat.jpg"),
+	    usage_key="chat:123",
+	    instructions="Be concise."
+	)
+
+The return value is a single string from the response output message text.

--- a/internal/starlark/llm/doc.go
+++ b/internal/starlark/llm/doc.go
@@ -1,0 +1,58 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+/*
+Package llm contains a Starlark module for generating text with the configured
+LLM provider.
+
+The module sends chat-style contents, optional image bytes, and optional
+instructions to the configured OpenAI Responses-compatible /responses endpoint.
+It returns the response's text output as a single string and records token usage
+under a caller-provided usage key.
+
+This is useful with the OpenAI API and with other AI providers that expose a
+compatible endpoint, such as OpenRouter.
+
+This module provides two functions: generate and usage.
+
+usage(key, date?) returns cumulative token usage for the key.
+If date is provided (YYYY-MM-DD), it returns usage only for that exact UTC day.
+
+generate accepts the following keyword arguments:
+
+  - model (str): Model name to generate with.
+  - contents (list of (str, str) tuples): A list of (role, content) messages.
+  - usage_key (str): Arbitrary key used to accumulate persistent token usage stats.
+  - image (bytes, optional): Optional raw image bytes to upload as input_image.
+  - instructions (str, optional): Optional high-level instructions for the model.
+
+For example:
+
+	text = llm.generate(
+	    model="gpt-4.1-mini",
+	    contents=[
+	        ("user", "Describe this image briefly.")
+	    ],
+	    image=files.read("cat.jpg"),
+	    usage_key="chat:123",
+	    instructions="Be concise."
+	)
+
+The return value is a single string from the response output message text.
+*/
+package llm
+
+import (
+	_ "embed"
+	"sync"
+
+	"go.astrophena.name/tools/internal/starlark/internal"
+)
+
+//go:embed doc.go
+var doc []byte
+
+var Documentation = sync.OnceValue(func() string {
+	return internal.ParseDocComment(doc)
+})

--- a/internal/starlark/llm/llm.go
+++ b/internal/starlark/llm/llm.go
@@ -1,0 +1,122 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package llm
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.astrophena.name/tools/internal/api/llm"
+	"go.astrophena.name/tools/internal/starlark/interpreter"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// Module returns a Starlark module that exposes a minimal Responses API call.
+func Module(client *llm.Client, usagePath string) *starlarkstruct.Module {
+	usage, err := newUsageStore(usagePath)
+	if err != nil {
+		usage = nil
+	}
+	m := &module{client: client, usage: usage}
+	return &starlarkstruct.Module{
+		Name: "llm",
+		Members: starlark.StringDict{
+			"generate": starlark.NewBuiltin("llm.generate", m.generate),
+			"usage":    starlark.NewBuiltin("llm.usage", m.getUsage),
+		},
+	}
+}
+
+type module struct {
+	client *llm.Client
+	usage  *usageStore
+}
+
+func (m *module) generate(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	ctx := interpreter.Context(thread)
+
+	if m.client == nil {
+		return starlark.None, fmt.Errorf("%s: LLM API is not available", b.Name())
+	}
+
+	var (
+		model        string
+		contentsList *starlark.List
+		instructions string
+		usageKey     string
+		image        starlark.Bytes
+	)
+
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"model", &model,
+		"contents", &contentsList,
+		"usage_key", &usageKey,
+		"image?", &image,
+		"instructions?", &instructions,
+	); err != nil {
+		return nil, err
+	}
+
+	messages := make([]llm.Message, 0, contentsList.Len()+1)
+	for i := range contentsList.Len() {
+		item, ok := contentsList.Index(i).(starlark.Tuple)
+		if !ok {
+			return nil, fmt.Errorf("%s: contents[%d] is not a tuple", b.Name(), i)
+		}
+		if len(item) != 2 {
+			return nil, fmt.Errorf("%s: contents[%d] must have exactly two elements: role and content", b.Name(), i)
+		}
+		role, ok := item.Index(0).(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("%s: in contents[%d] role must be a string", b.Name(), i)
+		}
+		content, ok := item.Index(1).(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("%s: in contents[%d] content must be a string", b.Name(), i)
+		}
+		messages = append(messages, llm.Message{Role: string(role), Content: []llm.ContentPart{{Type: "input_text", Text: string(content)}}})
+	}
+	if image.Len() > 0 {
+		mime := http.DetectContentType([]byte(image))
+		imageURL := "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString([]byte(image))
+		messages = append(messages, llm.Message{Role: "user", Content: []llm.ContentPart{{Type: "input_image", ImageURL: imageURL}}})
+	}
+
+	resp, err := m.client.CreateResponse(ctx, llm.ResponseParams{Model: model, Input: messages, Instructions: instructions})
+	if err != nil {
+		return starlark.None, fmt.Errorf("%s: failed to generate text: %w", b.Name(), err)
+	}
+	if m.usage != nil {
+		if err := m.usage.add(usageKey, time.Now(), resp.Usage.InputTokens, resp.Usage.OutputTokens); err != nil {
+			return starlark.None, fmt.Errorf("%s: failed to persist usage: %w", b.Name(), err)
+		}
+	}
+
+	return starlark.String(resp.OutputText), nil
+}
+
+func (m *module) getUsage(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		key  string
+		date string
+	)
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "key", &key, "date?", &date); err != nil {
+		return nil, err
+	}
+	if m.usage == nil {
+		return starlarkstruct.FromStringDict(starlark.String("usage"), starlark.StringDict{}), nil
+	}
+	u := m.usage.get(key, date)
+	return starlarkstruct.FromStringDict(starlark.String("usage"), starlark.StringDict{
+		"input_tokens":  starlark.MakeInt64(u.InputTokens),
+		"output_tokens": starlark.MakeInt64(u.OutputTokens),
+		"total_tokens":  starlark.MakeInt64(u.InputTokens + u.OutputTokens),
+	}), nil
+}

--- a/internal/starlark/llm/stats.go
+++ b/internal/starlark/llm/stats.go
@@ -1,0 +1,101 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package llm
+
+import (
+	"errors"
+	"io/fs"
+	"time"
+
+	"crawshaw.dev/jsonfile"
+)
+
+type usageStats struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+}
+
+type usageData struct {
+	ByKey map[string]usageKeyStats `json:"by_key"`
+}
+
+type usageKeyStats struct {
+	Total usageStats            `json:"total"`
+	ByDay map[string]usageStats `json:"by_day"`
+}
+
+type usageStore struct {
+	f *jsonfile.JSONFile[usageData]
+}
+
+func newUsageStore(path string) (*usageStore, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	f, err := jsonfile.Load[usageData](path)
+	if err != nil {
+		if !isNotExist(err) {
+			return nil, err
+		}
+		f, err = jsonfile.New[usageData](path)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = f.Write(func(d *usageData) error {
+		if d.ByKey == nil {
+			d.ByKey = make(map[string]usageKeyStats)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &usageStore{f: f}, nil
+}
+
+func isNotExist(err error) bool { return errors.Is(err, fs.ErrNotExist) }
+
+func (s *usageStore) add(key string, now time.Time, input, output int64) error {
+	if key == "" {
+		return nil
+	}
+	day := now.UTC().Format(time.DateOnly)
+	return s.f.Write(func(d *usageData) error {
+		if d.ByKey == nil {
+			d.ByKey = make(map[string]usageKeyStats)
+		}
+		v := d.ByKey[key]
+		if v.ByDay == nil {
+			v.ByDay = make(map[string]usageStats)
+		}
+		v.Total.InputTokens += input
+		v.Total.OutputTokens += output
+		daily := v.ByDay[day]
+		daily.InputTokens += input
+		daily.OutputTokens += output
+		v.ByDay[day] = daily
+		d.ByKey[key] = v
+		return nil
+	})
+}
+
+func (s *usageStore) get(key string, date string) usageStats {
+	var out usageStats
+	s.f.Read(func(d *usageData) {
+		v, ok := d.ByKey[key]
+		if !ok {
+			return
+		}
+		if date == "" {
+			out = v.Total
+			return
+		}
+		out = v.ByDay[date]
+	})
+	return out
+}


### PR DESCRIPTION
## Summary

Adds a new `llm` Starlark module for Starlet backed by an OpenAI Responses-compatible `/responses` API. This gives Starlet scripts a provider-neutral path for simple text generation through OpenAI or compatible providers such as OpenRouter.

## What changed

- Added `internal/api/llm`, a minimal Responses-compatible client with support for text/image input parts, instructions, token usage, and response text extraction from the real `output[].content[].text` response shape.
- Added `internal/starlark/llm` with `llm.generate(...)` and `llm.usage(...)`.
- Wired Starlet configuration through `LLM_API_KEY`, `LLM_API_URL`, and `LLM_USAGE_PATH`.
- Added generated Starlet documentation for the new module.
- Added unit coverage for response text extraction and an `rr` replay integration test for `CreateResponse`.

## Why

The existing Gemini-specific module is useful, but Starlet needs a simple LLM integration path that can use OpenAI models and OpenAI-compatible providers. The Responses API is a good fit for this bot because the expected usage is low volume, request/response oriented, and does not need a complex agent framework.

## Notes

- The integration fixture scrubs the request authorization header, normalizes the recorded request URL/model, removes response `Server` and `Set-Cookie` headers, and replaces the response `user` field with `example`.
- The response parser keeps `output_text` compatibility, but primarily handles the actual Responses API wire shape under `output`.

## Validation

- `go test -v ./internal/api/llm`
- `go tool pre-commit`

## Disclosure

This change was prepared with assistance from Codex.