### PR TITLE
internal/starlark/llm: encode assistant turns as output

### DIFF
--- a/internal/starlark/llm/llm.go
+++ b/internal/starlark/llm/llm.go
@@ -81,7 +81,7 @@ func (m *module) generate(thread *starlark.Thread, b *starlark.Builtin, args sta
 		if !ok {
 			return nil, fmt.Errorf("%s: in contents[%d] content must be a string", b.Name(), i)
 		}
-		messages = append(messages, llm.Message{Role: string(role), Content: []llm.ContentPart{{Type: "input_text", Text: string(content)}}})
+		messages = append(messages, llm.Message{Role: string(role), Content: []llm.ContentPart{{Type: contentPartType(string(role)), Text: string(content)}}})
 	}
 	if image.Len() > 0 {
 		mime := http.DetectContentType([]byte(image))
@@ -100,6 +100,15 @@ func (m *module) generate(thread *starlark.Thread, b *starlark.Builtin, args sta
 	}
 
 	return starlark.String(resp.OutputText), nil
+}
+
+func contentPartType(role string) string {
+	switch role {
+	case "assistant", "model":
+		return "output_text"
+	default:
+		return "input_text"
+	}
 }
 
 func (m *module) getUsage(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/starlark/llm/llm_test.go
+++ b/internal/starlark/llm/llm_test.go
@@ -1,0 +1,29 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package llm
+
+import (
+	"testing"
+
+	"go.astrophena.name/base/testutil"
+)
+
+func TestContentPartType(t *testing.T) {
+	cases := map[string]struct {
+		role string
+		want string
+	}{
+		"assistant":    {role: "assistant", want: "output_text"},
+		"legacy model": {role: "model", want: "output_text"},
+		"user":         {role: "user", want: "input_text"},
+		"system":       {role: "system", want: "input_text"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			testutil.AssertEqual(t, contentPartType(tc.role), tc.want)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes Starlet `llm.generate` conversation encoding so prior assistant turns are sent as Responses API `output_text` content instead of `input_text`.

## Why

A gateway rejected the second bot message with:

```text
Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'.
```

The failing item was a cached assistant turn. The LLM Starlark adapter was encoding every tuple in `contents` as `input_text`, regardless of role.

## What changed

- Added `contentPartType` to map `assistant` and legacy `model` roles to `output_text`.
- Kept user/system and other roles as `input_text`.
- Added table-driven coverage for the role-to-content-type mapping.

## Validation

- `go test ./internal/starlark/llm ./internal/api/llm ./cmd/starlet/internal/bot`
- `go tool pre-commit`

## Disclosure

This change was prepared with assistance from Codex.