### PR TITLE
cmd/tgfeed: speed up retry exhaustion test

### DIFF
--- a/cmd/tgfeed/fetch_test.go
+++ b/cmd/tgfeed/fetch_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/mmcdole/gofeed"
@@ -49,34 +50,39 @@ func TestFailingFeed(t *testing.T) {
 func TestRetryExhaustionCountsAsFailure(t *testing.T) {
 	t.Parallel()
 
-	var attempts atomic.Int32
-	env := newDefaultTestEnv(t, map[string]http.HandlerFunc{
-		atomFeedRoute: func(w http.ResponseWriter, r *http.Request) {
-			attempts.Add(1)
-			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
-		},
-	})
-	f := newTestFetcher(t, env)
-	if err := f.run(t.Context()); err != nil {
-		t.Fatal(err)
-	}
+	synctest.Test(t, func(t *testing.T) {
+		var attempts atomic.Int32
+		env := newDefaultTestEnv(t, map[string]http.HandlerFunc{
+			atomFeedRoute: func(w http.ResponseWriter, r *http.Request) {
+				attempts.Add(1)
+				http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			},
+		})
+		f := newTestFetcher(t, env)
+		if err := f.run(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.statsStore.Close(); err != nil {
+			t.Fatal(err)
+		}
 
-	state := env.state(t)
+		state := env.state(t)
 
-	testutil.AssertEqual(t, attempts.Load(), int32(retryLimit+1))
-	testutil.AssertEqual(t, state[atomFeedURL].ErrorCount, 1)
-	testutil.AssertEqual(t, state[atomFeedURL].FetchFailCount, int64(1))
-	if !strings.Contains(state[atomFeedURL].LastError, fmt.Sprintf("retry limit exceeded after %d retries", retryLimit)) {
-		t.Fatalf("unexpected last error: %q", state[atomFeedURL].LastError)
-	}
+		testutil.AssertEqual(t, attempts.Load(), int32(retryLimit+1))
+		testutil.AssertEqual(t, state[atomFeedURL].ErrorCount, 1)
+		testutil.AssertEqual(t, state[atomFeedURL].FetchFailCount, int64(1))
+		if !strings.Contains(state[atomFeedURL].LastError, fmt.Sprintf("retry limit exceeded after %d retries", retryLimit)) {
+			t.Fatalf("unexpected last error: %q", state[atomFeedURL].LastError)
+		}
 
-	f.stats.ReadAccess(func(s *tgstats.Run) {
-		testutil.AssertEqual(t, s.FailedFeeds, 1)
-		testutil.AssertEqual(t, s.SuccessFeeds, 0)
-		testutil.AssertEqual(t, s.NotModifiedFeeds, 0)
-		testutil.AssertEqual(t, s.FetchRetriesTotal, retryLimit)
-		testutil.AssertEqual(t, s.FeedsRetriedCount, 1)
-		testutil.AssertEqual(t, s.HTTP5xxCount, retryLimit+1)
+		f.stats.ReadAccess(func(s *tgstats.Run) {
+			testutil.AssertEqual(t, s.FailedFeeds, 1)
+			testutil.AssertEqual(t, s.SuccessFeeds, 0)
+			testutil.AssertEqual(t, s.NotModifiedFeeds, 0)
+			testutil.AssertEqual(t, s.FetchRetriesTotal, retryLimit)
+			testutil.AssertEqual(t, s.FeedsRetriedCount, 1)
+			testutil.AssertEqual(t, s.HTTP5xxCount, retryLimit+1)
+		})
 	})
 }
 


### PR DESCRIPTION
## Summary

- Wrap the retry exhaustion test in testing/synctest so retry backoff advances under fake time.
- Close the stats store before leaving the synctest bubble so database/sql background goroutines do not leak.

## Impact

This keeps the retry exhaustion coverage while removing the real 15 second sleep from the tgfeed test package.

## Validation

- go tool pre-commit

## AI disclosure

This PR was prepared with assistance from OpenAI Codex.