### PR TITLE
cmd/tgfeed: avoid unused state directory creation

### DIFF
--- a/cmd/tgfeed/main.go
+++ b/cmd/tgfeed/main.go
@@ -113,20 +113,22 @@ func (f *fetcher) Run(ctx context.Context) error {
 	f.ghToken = cmp.Or(f.ghToken, env.Getenv("GITHUB_TOKEN"))
 	f.stateDir = cmp.Or(f.stateDir, env.Getenv("STATE_DIRECTORY"))
 	if f.stateDir == "" {
-		xdgStateHome := env.Getenv("XDG_STATE_HOME")
-		if xdgStateHome == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return err
-			}
-			xdgStateHome = filepath.Join(home, ".local", "state")
+		stateDir, err := defaultStateDir(env)
+		if err != nil {
+			return err
 		}
-		f.stateDir = filepath.Join(xdgStateHome, "tgfeed")
+		f.stateDir = stateDir
+	}
+	f.tgToken = cmp.Or(f.tgToken, env.Getenv("TELEGRAM_TOKEN"))
+
+	if len(env.Args) == 0 {
+		return fmt.Errorf("%w: command is required, see -help for usage", cli.ErrInvalidArgs)
+	}
+	if f.needsLocalStateDir(env.Args[0]) {
 		if err := os.MkdirAll(f.stateDir, 0o700); err != nil {
 			return err
 		}
 	}
-	f.tgToken = cmp.Or(f.tgToken, env.Getenv("TELEGRAM_TOKEN"))
 
 	f.init.Do(func() {
 		f.doInit(ctx)
@@ -134,10 +136,6 @@ func (f *fetcher) Run(ctx context.Context) error {
 
 	if f.dry {
 		f.slogLevel.Set(slog.LevelDebug)
-	}
-
-	if len(env.Args) == 0 {
-		return fmt.Errorf("%w: command is required, see -help for usage", cli.ErrInvalidArgs)
 	}
 
 	switch env.Args[0] {
@@ -177,6 +175,22 @@ func (f *fetcher) Run(ctx context.Context) error {
 	default:
 		return fmt.Errorf("%w: no such command %q", cli.ErrInvalidArgs, env.Args[0])
 	}
+}
+
+func defaultStateDir(env *cli.Env) (string, error) {
+	xdgStateHome := env.Getenv("XDG_STATE_HOME")
+	if xdgStateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		xdgStateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(xdgStateHome, "tgfeed"), nil
+}
+
+func (f *fetcher) needsLocalStateDir(command string) bool {
+	return f.remoteURL == "" || slices.Contains([]string{"admin", "run"}, command)
 }
 
 // Run orchestration.

--- a/cmd/tgfeed/main_test.go
+++ b/cmd/tgfeed/main_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -95,6 +96,45 @@ func TestFetcherMain(t *testing.T) {
 		},
 	},
 	)
+}
+
+func TestRemoteClientDoesNotCreateStateDir(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`feed(url="https://example.com/feed.xml")`))
+	})
+	mux.HandleFunc("/api/state", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("/api/error-template", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	xdgStateHome := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	env := &cli.Env{
+		Args: []string{"-remote", server.URL, "feeds"},
+		Getenv: func(key string) string {
+			if key == "XDG_STATE_HOME" {
+				return xdgStateHome
+			}
+			return ""
+		},
+		Stdin:  strings.NewReader(""),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	if err := cli.Run(cli.WithEnv(t.Context(), env), new(fetcher)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(xdgStateHome, "tgfeed")); !os.IsNotExist(err) {
+		t.Fatalf("remote client created state directory: %v", err)
+	}
 }
 
 func TestListFeeds(t *testing.T) {


### PR DESCRIPTION
## Summary

- Resolve the default tgfeed state directory without creating it during early startup.
- Create the local state directory only for local mode, or for commands that still require local runtime files.
- Add a regression test covering remote client usage with XDG_STATE_HOME.

## Impact

Remote-only client commands such as tgfeed -remote URL feeds no longer create a local XDG state directory when they do not need one.

## Root cause

Startup created the default state directory while resolving STATE_DIRECTORY before command dispatch, so remote client commands paid the local setup cost even though state access went through the admin API.

## Validation

- go tool pre-commit

## AI disclosure

This PR was prepared with assistance from OpenAI Codex.