### PR TITLE
cmd/boot: add host setup tool

### DIFF
--- a/cmd/boot/doc.go
+++ b/cmd/boot/doc.go
@@ -1,0 +1,138 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+/*
+Boot applies a Starlark recipe to bring a development environment into the
+state described by that recipe. It is intended for personal workstation and
+shell-environment bootstrap tasks: package installation, dotfile links, Git
+checkouts, generated keys, timers, and other small host maintenance actions.
+
+Boot recipes register named tasks. When a task runs, it emits idempotent
+actions through built-in modules such as fs, git, pkg, go, systemd, shell, and
+ssh. Boot then checks each action and either skips it, reports that it would
+change the host, or applies it.
+
+Boot is deliberately smaller than Ansible. Recipes are ordinary Starlark files,
+module APIs are narrow Go wrappers, and the plan/apply split is the main safety
+mechanism.
+
+# Usage
+
+	$ boot [flags...] <command>
+
+Where <command> is one of the following commands:
+
+	list
+		List selected tasks without running them.
+
+	plan
+		Evaluate selected tasks and print the actions they would take without
+		changing the host.
+
+	check
+		Alias for plan intended for validation scripts.
+
+	apply
+		Evaluate selected tasks and apply their actions.
+
+# Flags
+
+	-C dir
+		Run as if boot was started in dir. Defaults to the current directory.
+
+	-f file
+		Starlark recipe entrypoint. Defaults to BOOT.star.
+
+	-dry-run
+		Alias for plan.
+
+	-json
+		Print machine-readable JSON output.
+
+	-fail-fast
+		Stop on the first failed task.
+
+	-only task
+		Run only the specified task ID. May be repeated.
+
+	-skip task
+		Skip the specified task ID. May be repeated.
+
+	-tag tag
+		Run tasks with the specified tag. May be repeated.
+
+	-j concurrency
+		Number of tasks to run in parallel. Defaults to 1.
+
+# Recipes
+
+Recipes are Starlark files loaded from the directory selected by -C. The default
+entrypoint is BOOT.star. Top-level code should detect the current machine and
+register tasks; task functions should emit actions and avoid doing direct host
+mutation themselves:
+
+	# vim: ft=starlark shiftwidth=4
+
+	def dotfiles():
+	    fs.dir("~/local/data/bash")
+	    fs.symlink("bash/rc", "~/.bashrc")
+
+	def supported():
+	    if env.get("HOME") == "":
+	        fail("HOME is required")
+
+	task(
+	    id="dotfiles",
+	    name="Link dotfiles",
+	    tags=["filesystem"],
+	    run=dotfiles,
+	)
+
+Tasks may declare tags, dependencies, whether failures should be continuable,
+and whether sudo should be prepared before apply. Select tasks with -only,
+-skip, and -tag.
+
+For built-in module documentation, see cmd/boot/modules.md.
+
+# Safety
+
+The plan command runs action checks but does not apply changes. Actions should
+therefore make dry-run checks cheap and side-effect free. Use consent.require
+inside a task when an apply needs an explicit user acknowledgement before later
+actions in that task proceed.
+
+For system tasks, set requires_sudo=True on the task so Boot can authenticate
+once before apply. Individual modules still decide when sudo is necessary.
+
+The apply command holds a per-recipe advisory lock so two Boot runs cannot race
+the same package manager or filesystem actions.
+
+# Environment Variables
+
+Boot reads the following environment variables:
+
+	HOME
+		Used when expanding paths that begin with ~/.
+
+	BOOT_PACKAGE_MANAGER
+		Default package manager for pkg.install when pkg.configure is not used.
+
+	NO_COLOR
+		Disable colored output.
+
+	CI
+		Disable interactive prompts when set to true.
+*/
+package main
+
+import (
+	_ "embed"
+
+	"go.astrophena.name/base/cli"
+)
+
+//go:embed doc.go
+var doc []byte
+
+func init() { cli.SetDocComment(doc) }

--- a/cmd/boot/internal/README.md
+++ b/cmd/boot/internal/README.md
@@ -1,0 +1,140 @@
+# Hacking on Boot
+
+Boot is a small Starlark runtime for host setup recipes. The public binary lives
+in `cmd/boot`; this package contains the task engine, runtime state, and module
+contracts used by the built-in modules.
+
+## Runtime Model
+
+`main.go` builds an `internal.Engine` with:
+
+- a `Runtime`, which stores recipe root, home directory, environment access,
+  stdio, and whether the current run is interactive;
+- an entrypoint, normally `BOOT.star`;
+- a list of modules, each exposed as a Starlark module.
+
+`Engine.Load` executes the entrypoint with predeclared globals:
+
+- `task(...)` registers a task;
+- `fail(message)` stops recipe evaluation;
+- each Go module appears under its module name, such as `fs` or `pkg`.
+
+Top-level Starlark should only register tasks and choose machine profiles. Host
+mutation belongs in task functions through module actions.
+
+## Tasks and Actions
+
+A task is a named Starlark callable. When the engine runs a task, it attaches
+the task to the Starlark thread with `SetTask`. Module functions validate
+`InTask(thread)` and call `AddAction(thread, Action{...})`.
+
+An `Action` has:
+
+- `Summary`, printed in plans, verbose applies, and failures;
+- `Apply(ctx, dryRun)`, which checks or applies one idempotent operation.
+
+Action results are:
+
+- `ResultSkip`: the host already matched the requested state;
+- `ResultChange`: the action changed the host or would change it in dry-run;
+- `ResultWarn`: the action found a non-fatal issue;
+- `ResultStop`: stop the remaining actions in this task without failing.
+
+Use `ResultStop` only for gating actions such as `consent.require`; normal
+idempotency should use skip/change.
+
+## Writing Modules
+
+Modules implement:
+
+```go
+type Module interface {
+    Name() string
+    Members(*Runtime) starlark.StringDict
+}
+```
+
+Keep module APIs narrow and recipe-oriented. Prefer one clear Starlark function
+that emits one idempotent action over a general-purpose command wrapper.
+
+Module function checklist:
+
+- Require task context for functions that emit actions.
+- Parse arguments with `starlark.UnpackArgs`.
+- Resolve recipe inputs with `Runtime.ResolveSource`.
+- Resolve host targets with `Runtime.ResolveTarget`.
+- Use `Runtime.ExpandHome` or `Runtime.Hostname` rather than duplicating that
+  logic.
+- Do not mutate the host while registering actions.
+- In dry-run, perform enough checks to decide skip/change but do not write.
+- Include command output in returned errors; use `boot.CommandError` when it
+  fits.
+- Keep successful JSON or textual output minimal; noisy reporting belongs in
+  explicit check modules.
+
+Avoid external dependencies for modules unless the standard library would make
+the code fragile or much larger.
+
+## Debugging Modules
+
+Start with a focused recipe and task selection:
+
+```sh
+go run ./cmd/boot -C ~/code/prefs -only setup_packages plan
+go run ./cmd/boot -C ~/code/prefs -only setup_packages -verbose apply
+```
+
+Use `plan` to verify the action list and idempotency checks. Use `-verbose
+apply` when you need per-action skip/change output. For task filtering bugs,
+`boot list`, `-only`, `-skip`, and `-tag` exercise the selection path without
+running actions.
+
+Use `--json` when another program needs stable output. JSON runs intentionally
+use a simpler sequential execution path so action results are ordered and easy
+to consume.
+
+When debugging command execution, prefer fake commands in a temporary `PATH`
+inside tests. See the `packages`, `systemd`, and `rescue` tests for examples.
+
+## Testing
+
+Put module tests next to the module. Use `testutil.TaskThread` to create a task
+and Starlark thread, call the module function, then run the emitted action.
+
+Typical shape:
+
+```go
+task, thread := testutil.TaskThread("test")
+m := &impl{rt: &boot.Runtime{Root: root, Home: home, Getenv: os.Getenv}}
+_, err := m.someFunction(thread, starlark.NewBuiltin("module.func", m.someFunction), nil, kwargs)
+if err != nil {
+    t.Fatal(err)
+}
+got, err := task.Actions[0].Apply(context.Background(), true)
+```
+
+Tests should cover both dry-run and apply behavior when a function can write.
+For command-based modules, create small executable shell scripts with
+`testutil.WriteCommand` and prepend their directory to `PATH`.
+
+Before submitting changes, run from the repository root:
+
+```sh
+go tool pre-commit
+```
+
+## Recipe Compatibility
+
+Boot currently targets the prefs setup recipes, so compatibility with the old
+`automation/setup` behavior matters. Be careful around:
+
+- package updates, which may need explicit consent;
+- maintenance checks, which should warn unless the recipe intentionally wants a
+  hard failure;
+- environment loading before tools that rely on `GOBIN`, `GOPATH`, or XDG
+  variables;
+- dry-run behavior for system modules.
+
+When replacing old setup behavior, read the old Python task and port the
+observable behavior first. Then simplify only when the new behavior is
+intentional and documented.

--- a/cmd/boot/internal/command.go
+++ b/cmd/boot/internal/command.go
@@ -1,0 +1,37 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package internal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// RunCommand runs argv and includes combined output in returned errors.
+func RunCommand(ctx context.Context, dir string, argv ...string) error {
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return CommandError(argv, buf.Bytes(), err)
+	}
+	return nil
+}
+
+// CommandError formats a command failure with trimmed command output.
+func CommandError(argv []string, out []byte, err error) error {
+	msg := strings.TrimSpace(string(out))
+	if msg == "" {
+		return fmt.Errorf("%s failed: %w", strings.Join(argv, " "), err)
+	}
+	return fmt.Errorf("%s failed: %w:\n%s", strings.Join(argv, " "), err, msg)
+}

--- a/cmd/boot/internal/consent/consent.go
+++ b/cmd/boot/internal/consent/consent.go
@@ -1,0 +1,116 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package consent provides Starlark actions for interactive user consent.
+package consent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark consent module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "consent" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"require": starlark.NewBuiltin("consent.require", m.require),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) require(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		message    string
+		defaultYes bool
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"message", &message,
+		"default?", &defaultYes,
+	); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(message) == "" {
+		return nil, fmt.Errorf("%s: message cannot be empty", b.Name())
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: "confirm: " + message,
+		Apply: func(_ context.Context, dryRun bool) (boot.Result, error) {
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if m.rt != nil && !m.rt.Interactive {
+				return boot.ResultStop, nil
+			}
+			ok, err := ask(m.rt, message, defaultYes)
+			if err != nil {
+				return "", err
+			}
+			if !ok {
+				return boot.ResultStop, nil
+			}
+			return boot.ResultSkip, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func ask(rt *boot.Runtime, message string, defaultYes bool) (bool, error) {
+	in := io.Reader(os.Stdin)
+	out := io.Writer(os.Stdout)
+	if rt != nil {
+		if rt.Stdin != nil {
+			in = rt.Stdin
+		}
+		if rt.Stdout != nil {
+			out = rt.Stdout
+		}
+	}
+
+	prompt := " [y/N] "
+	if defaultYes {
+		prompt = " [Y/n] "
+	}
+	if _, err := fmt.Fprint(out, message, prompt); err != nil {
+		return false, err
+	}
+
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	switch answer {
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	case "":
+		return defaultYes, nil
+	default:
+		return false, nil
+	}
+}

--- a/cmd/boot/internal/consent/consent_test.go
+++ b/cmd/boot/internal/consent/consent_test.go
@@ -1,0 +1,76 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package consent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+	"go.starlark.net/starlark"
+)
+
+func TestRequire(t *testing.T) {
+	cases := map[string]struct {
+		interactive bool
+		input       string
+		defaultYes  bool
+		dryRun      bool
+		want        boot.Result
+	}{
+		"dry run plans change": {
+			dryRun: true,
+			want:   boot.ResultChange,
+		},
+		"non-interactive stops task": {
+			want: boot.ResultStop,
+		},
+		"accepted": {
+			interactive: true,
+			input:       "yes\n",
+			want:        boot.ResultSkip,
+		},
+		"denied": {
+			interactive: true,
+			input:       "no\n",
+			want:        boot.ResultStop,
+		},
+		"default accepted": {
+			interactive: true,
+			defaultYes:  true,
+			input:       "\n",
+			want:        boot.ResultSkip,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rt := &boot.Runtime{
+				Stdin:       strings.NewReader(tc.input),
+				Stdout:      new(strings.Builder),
+				Interactive: tc.interactive,
+			}
+			task, thread := testutil.TaskThread("test")
+			m := &impl{rt: rt}
+			kwargs := []starlark.Tuple{{starlark.String("message"), starlark.String("Proceed?")}}
+			if tc.defaultYes {
+				kwargs = append(kwargs, starlark.Tuple{starlark.String("default"), starlark.True})
+			}
+			_, err := m.require(thread, starlark.NewBuiltin("consent.require", m.require), nil, kwargs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := task.Actions[0].Apply(context.Background(), tc.dryRun)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("result = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/boot/internal/doc.go
+++ b/cmd/boot/internal/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package internal contains the runtime for executing boot Starlark recipes.
+package internal

--- a/cmd/boot/internal/engine.go
+++ b/cmd/boot/internal/engine.go
@@ -1,0 +1,841 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"sync"
+	"text/tabwriter"
+
+	"go.astrophena.name/base/cli/progressbar"
+	"go.astrophena.name/tools/internal/starlark/interpreter"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+	"golang.org/x/sync/errgroup"
+)
+
+// Engine loads recipes, registers tasks, and runs selected tasks.
+type Engine struct {
+	Runtime *Runtime
+	Entry   string
+	Modules []Module
+
+	Tasks []*Task
+}
+
+// Task is a recipe-defined unit of work.
+type Task struct {
+	ID              string
+	Name            string
+	Tags            []string
+	DependsOn       []string
+	ContinueOnError bool
+	RequiresSudo    bool
+	Run             starlark.Callable
+	Actions         []Action
+}
+
+// Action is an idempotent operation emitted by a task.
+type Action struct {
+	Summary string
+	Apply   func(context.Context, bool) (Result, error)
+}
+
+// Result describes what an action did.
+type Result string
+
+const (
+	// ResultSkip means the host already matched the requested state.
+	ResultSkip Result = "skip"
+	// ResultChange means the action changed the host or would change it in dry-run mode.
+	ResultChange Result = "change"
+	// ResultWarn means the action found a non-fatal problem.
+	ResultWarn Result = "warn"
+	// ResultStop means no further actions in the current task should run.
+	ResultStop Result = "stop"
+)
+
+// Selection controls which tasks are listed or run.
+type Selection struct {
+	Only []string
+	Skip []string
+	Tags []string
+}
+
+// RunOptions controls task execution.
+type RunOptions struct {
+	DryRun      bool
+	FailFast    bool
+	Interactive bool
+	Concurrency int
+	Color       bool
+	Verbose     bool
+	JSON        bool
+}
+
+// Summary describes the outcome of a run.
+type Summary struct {
+	Tasks    int `json:"tasks"`
+	Actions  int `json:"actions"`
+	Changed  int `json:"changed"`
+	Skipped  int `json:"skipped"`
+	Warnings int `json:"warnings"`
+	Failed   int `json:"failed"`
+}
+
+// Load executes the entrypoint and registers tasks.
+func (e *Engine) Load(ctx context.Context) error {
+	predeclared := starlark.StringDict{
+		"fail":   starlark.NewBuiltin("fail", fail),
+		"task":   starlark.NewBuiltin("task", e.starlarkTask),
+		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
+	}
+	for _, mod := range e.Modules {
+		predeclared[mod.Name()] = &starlarkstruct.Module{
+			Name:    mod.Name(),
+			Members: mod.Members(e.Runtime),
+		}
+	}
+
+	intr := &interpreter.Interpreter{
+		Predeclared: predeclared,
+		Packages: map[string]interpreter.Loader{
+			interpreter.MainPkg: interpreter.FileSystemLoader(e.Runtime.Root),
+		},
+	}
+	if err := intr.Init(ctx); err != nil {
+		return err
+	}
+	_, err := intr.ExecModule(ctx, interpreter.MainPkg, e.Entry)
+	if errors.Is(err, interpreter.ErrNoModule) || errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("recipe %s not found in %s", e.Entry, e.Runtime.Root)
+	}
+	return err
+}
+
+func fail(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var message string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "message", &message); err != nil {
+		return nil, err
+	}
+	if message == "" {
+		return nil, errors.New("failed")
+	}
+	return nil, errors.New(message)
+}
+
+// List writes selected task metadata.
+func (e *Engine) List(w io.Writer, selection Selection) error {
+	tasks, err := e.Selected(selection)
+	if err != nil {
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tNAME\tTAGS")
+	for _, task := range tasks {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", task.ID, task.Name, strings.Join(task.Tags, ","))
+	}
+	return tw.Flush()
+}
+
+// Run runs selected tasks.
+func (e *Engine) Run(ctx context.Context, w io.Writer, selection Selection, opts RunOptions) error {
+	if e.Runtime != nil {
+		e.Runtime.Interactive = opts.Interactive
+	}
+	if opts.JSON {
+		return e.runJSON(ctx, w, selection, opts)
+	}
+	if opts.DryRun {
+		return e.plan(ctx, w, selection, opts)
+	}
+	if opts.Verbose {
+		return e.applyVerbose(ctx, w, selection, opts)
+	}
+	return e.apply(ctx, w, selection, opts)
+}
+
+func (e *Engine) plan(ctx context.Context, w io.Writer, selection Selection, opts RunOptions) error {
+	tasks, err := e.Selected(selection)
+	if err != nil {
+		return err
+	}
+	summary := Summary{Tasks: len(tasks)}
+
+	for i, task := range tasks {
+		stop := false
+		fmt.Fprintf(w, "[%d/%d] Planning task %s: %s\n", i+1, len(tasks), task.ID, task.Name)
+		task.Actions = nil
+		thread := &starlark.Thread{Name: "boot:" + task.ID}
+		SetTask(thread, task)
+		if _, err := starlark.Call(thread, task.Run, nil, nil); err != nil {
+			summary.Failed++
+			fmt.Fprintf(w, "%s %s: %v\n", e.color("fail", colorRed), task.ID, err)
+			if opts.FailFast && !task.ContinueOnError {
+				break
+			}
+			continue
+		}
+		for _, action := range task.Actions {
+			summary.Actions++
+			result, err := action.Apply(ctx, true)
+			if err != nil {
+				summary.Failed++
+				fmt.Fprintf(w, "%s %s: %s: %v\n", e.color("fail", colorRed), task.ID, action.Summary, err)
+				if opts.FailFast && !task.ContinueOnError {
+					stop = true
+					break
+				}
+				continue
+			}
+			switch result {
+			case ResultChange:
+				summary.Changed++
+				fmt.Fprintf(w, "%s %s: %s\n", e.color(string(result), colorGreen), task.ID, action.Summary)
+			case ResultSkip:
+				summary.Skipped++
+			case ResultWarn:
+				summary.Warnings++
+				fmt.Fprintf(w, "%s %s: %s\n", e.color(string(result), colorRed), task.ID, action.Summary)
+			case ResultStop:
+				summary.Skipped++
+			}
+		}
+		if stop {
+			break
+		}
+	}
+
+	fmt.Fprintf(
+		w,
+		"summary: %d tasks, %d actions, %d would change, %d skipped, %d warnings, %d failed\n",
+		summary.Tasks,
+		summary.Actions,
+		summary.Changed,
+		summary.Skipped,
+		summary.Warnings,
+		summary.Failed,
+	)
+	if summary.Failed > 0 {
+		return errors.New("one or more tasks failed")
+	}
+	return nil
+}
+
+func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, opts RunOptions) error {
+	tasks, err := e.Selected(selection)
+	if err != nil {
+		return err
+	}
+	if err := e.prepareSudo(ctx, tasks); err != nil {
+		return err
+	}
+	summary := Summary{
+		Tasks: len(tasks),
+	}
+
+	concurrency := max(opts.Concurrency, 1)
+
+	pb := progressbar.New(w, len(tasks), opts.Interactive)
+	pb.Start()
+
+	var (
+		mu          sync.Mutex
+		hadFailures bool
+		stopOnError bool
+		failures    []failure
+	)
+
+	doneCh := make(map[string]chan struct{})
+	for _, task := range tasks {
+		doneCh[task.ID] = make(chan struct{})
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
+	for _, task := range tasks {
+		g.Go(func() error {
+			defer close(doneCh[task.ID])
+
+			for _, dep := range task.DependsOn {
+				if ch, ok := doneCh[dep]; ok {
+					select {
+					case <-ch:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			}
+
+			mu.Lock()
+			if stopOnError && opts.FailFast {
+				mu.Unlock()
+				return nil
+			}
+			mu.Unlock()
+
+			task.Actions = nil
+
+			pb.SetTitle(task.Name)
+			thread := &starlark.Thread{Name: "boot:" + task.ID}
+			SetTask(thread, task)
+			_, err := starlark.Call(thread, task.Run, nil, nil)
+			if err != nil {
+				mu.Lock()
+				hadFailures = true
+				if !task.ContinueOnError {
+					stopOnError = true
+				}
+				summary.Failed++
+				failures = append(failures, failure{TaskID: task.ID, TaskName: task.Name, Err: err})
+				mu.Unlock()
+
+				if opts.FailFast && !task.ContinueOnError {
+					pb.Increment()
+					return err
+				}
+				pb.Increment()
+				return nil
+			}
+
+			for _, action := range task.Actions {
+				mu.Lock()
+				summary.Actions++
+				mu.Unlock()
+
+				result, err := action.Apply(ctx, opts.DryRun)
+				if err != nil {
+					mu.Lock()
+					hadFailures = true
+					if !task.ContinueOnError {
+						stopOnError = true
+					}
+					summary.Failed++
+					failures = append(failures, failure{
+						TaskID:   task.ID,
+						TaskName: task.Name,
+						Action:   action.Summary,
+						Err:      err,
+					})
+					mu.Unlock()
+
+					if opts.FailFast && !task.ContinueOnError {
+						pb.Increment()
+						return err
+					}
+					continue
+				}
+
+				mu.Lock()
+				switch result {
+				case ResultChange:
+					summary.Changed++
+				case ResultSkip:
+					summary.Skipped++
+				case ResultWarn:
+					summary.Warnings++
+				case ResultStop:
+					summary.Skipped++
+				}
+				mu.Unlock()
+				if result == ResultStop {
+					break
+				}
+			}
+
+			pb.Increment()
+			return nil
+		})
+	}
+
+	err = g.Wait()
+	pb.Stop(hadFailures || err != nil)
+
+	if err != nil && !hadFailures {
+		failures = append(failures, failure{Err: err})
+	}
+	e.printReport(w, summary, false)
+	if err := e.printFailures(w, failures); err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	if hadFailures {
+		return errors.New("one or more tasks failed")
+	}
+	return nil
+}
+
+func (e *Engine) applyVerbose(ctx context.Context, w io.Writer, selection Selection, opts RunOptions) error {
+	tasks, err := e.Selected(selection)
+	if err != nil {
+		return err
+	}
+	if err := e.prepareSudo(ctx, tasks); err != nil {
+		return err
+	}
+	summary := Summary{Tasks: len(tasks)}
+	var failures []failure
+
+	for i, task := range tasks {
+		stop := false
+		fmt.Fprintf(w, "[%d/%d] Applying task %s: %s\n", i+1, len(tasks), task.ID, task.Name)
+		task.Actions = nil
+		thread := &starlark.Thread{Name: "boot:" + task.ID}
+		SetTask(thread, task)
+		if _, err := starlark.Call(thread, task.Run, nil, nil); err != nil {
+			summary.Failed++
+			failures = append(failures, failure{TaskID: task.ID, TaskName: task.Name, Err: err})
+			if opts.FailFast && !task.ContinueOnError {
+				break
+			}
+			continue
+		}
+		for _, action := range task.Actions {
+			summary.Actions++
+			result, err := action.Apply(ctx, false)
+			if err != nil {
+				summary.Failed++
+				failures = append(failures, failure{
+					TaskID:   task.ID,
+					TaskName: task.Name,
+					Action:   action.Summary,
+					Err:      err,
+				})
+				if opts.FailFast && !task.ContinueOnError {
+					stop = true
+					break
+				}
+				continue
+			}
+			switch result {
+			case ResultChange:
+				summary.Changed++
+				fmt.Fprintf(w, "%s %s: %s\n", e.color(string(result), colorGreen), task.ID, action.Summary)
+			case ResultSkip:
+				summary.Skipped++
+				fmt.Fprintf(w, "skip %s: %s\n", task.ID, action.Summary)
+			case ResultWarn:
+				summary.Warnings++
+				fmt.Fprintf(w, "%s %s: %s\n", e.color(string(result), colorRed), task.ID, action.Summary)
+			case ResultStop:
+				summary.Skipped++
+				fmt.Fprintf(w, "skip %s: %s\n", task.ID, action.Summary)
+				stop = true
+			}
+		}
+		if stop {
+			break
+		}
+	}
+
+	e.printReport(w, summary, false)
+	if err := e.printFailures(w, failures); err != nil {
+		return err
+	}
+	if summary.Failed > 0 {
+		return errors.New("one or more tasks failed")
+	}
+	return nil
+}
+
+type failure struct {
+	TaskID   string
+	TaskName string
+	Action   string
+	Err      error
+}
+
+func (e *Engine) printReport(w io.Writer, summary Summary, dryRun bool) {
+	changeText := "changed"
+	if dryRun {
+		changeText = "would change"
+	}
+	fmt.Fprintf(w, "%s\n", e.color("Report:", colorBold))
+	fmt.Fprintf(w, "  Boot ran %d %s and checked %d %s.\n",
+		summary.Tasks,
+		plural(summary.Tasks, "task", "tasks"),
+		summary.Actions,
+		plural(summary.Actions, "action", "actions"),
+	)
+	fmt.Fprintf(w, "  It %s %s and skipped %s.\n",
+		changeText,
+		e.color(fmt.Sprintf("%d %s", summary.Changed, plural(summary.Changed, "action", "actions")), colorGreen),
+		fmt.Sprintf("%d %s", summary.Skipped, plural(summary.Skipped, "action", "actions")),
+	)
+	if summary.Warnings > 0 {
+		fmt.Fprintf(w, "  It reported %s.\n", e.color(fmt.Sprintf("%d %s", summary.Warnings, plural(summary.Warnings, "warning", "warnings")), colorRed))
+	}
+	if summary.Failed == 0 {
+		fmt.Fprintf(w, "  %s\n", e.color("No actions failed.", colorGreen))
+		return
+	}
+	fmt.Fprintf(w, "  %s\n", e.color(fmt.Sprintf("%d %s failed.", summary.Failed, plural(summary.Failed, "action", "actions")), colorRed))
+}
+
+func (e *Engine) printFailures(w io.Writer, failures []failure) error {
+	if len(failures) == 0 {
+		return nil
+	}
+	fmt.Fprintf(w, "%s\n", e.color("errors:", colorRed))
+	for _, failure := range failures {
+		logPath, err := writeFailureLog(failure)
+		if err != nil {
+			return err
+		}
+		if failure.TaskID != "" {
+			fmt.Fprintf(w, "%s\n", e.color(fmt.Sprintf("  task: %s (%s)", failure.TaskID, failure.TaskName), colorRed))
+		}
+		if failure.Action != "" {
+			fmt.Fprintf(w, "%s\n", e.color("    action: "+failure.Action, colorRed))
+		}
+		fmt.Fprintf(w, "%s\n", e.color("    error: "+firstLine(failure.Err.Error()), colorRed))
+		fmt.Fprintf(w, "%s\n", e.color("    log: "+logPath, colorRed))
+		if output := restLines(failure.Err.Error()); output != "" {
+			fmt.Fprintf(w, "%s\n", e.color("    output:", colorRed))
+			for line := range strings.SplitSeq(output, "\n") {
+				fmt.Fprintf(w, "%s\n", e.color("      "+line, colorRed))
+			}
+		}
+	}
+	return nil
+}
+
+func writeFailureLog(f failure) (string, error) {
+	file, err := os.CreateTemp("", "boot-error-*.log")
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	if f.TaskID != "" {
+		fmt.Fprintf(file, "task: %s (%s)\n", f.TaskID, f.TaskName)
+	}
+	if f.Action != "" {
+		fmt.Fprintf(file, "action: %s\n", f.Action)
+	}
+	fmt.Fprintf(file, "error:\n%s\n", f.Err)
+	return file.Name(), nil
+}
+
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(s, "\n")
+	return line
+}
+
+func restLines(s string) string {
+	_, rest, ok := strings.Cut(strings.TrimSpace(s), "\n")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(rest)
+}
+
+func plural(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+type jsonRun struct {
+	DryRun  bool         `json:"dry_run"`
+	Summary Summary      `json:"summary"`
+	Actions []jsonAction `json:"actions"`
+}
+
+type jsonAction struct {
+	TaskID   string `json:"task_id"`
+	TaskName string `json:"task_name"`
+	Summary  string `json:"summary,omitempty"`
+	Result   Result `json:"result,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+func (e *Engine) runJSON(ctx context.Context, w io.Writer, selection Selection, opts RunOptions) error {
+	if e.Runtime != nil {
+		oldStdout := e.Runtime.Stdout
+		e.Runtime.Stdout = io.Discard
+		defer func() { e.Runtime.Stdout = oldStdout }()
+	}
+	tasks, err := e.Selected(selection)
+	if err != nil {
+		return err
+	}
+	if !opts.DryRun {
+		if err := e.prepareSudo(ctx, tasks); err != nil {
+			return err
+		}
+	}
+
+	report := jsonRun{DryRun: opts.DryRun, Summary: Summary{Tasks: len(tasks)}}
+	for _, task := range tasks {
+		task.Actions = nil
+		thread := &starlark.Thread{Name: "boot:" + task.ID}
+		SetTask(thread, task)
+		if _, err := starlark.Call(thread, task.Run, nil, nil); err != nil {
+			report.Summary.Failed++
+			report.Actions = append(report.Actions, jsonAction{TaskID: task.ID, TaskName: task.Name, Error: err.Error()})
+			if opts.FailFast && !task.ContinueOnError {
+				break
+			}
+			continue
+		}
+		stop := false
+		for _, action := range task.Actions {
+			report.Summary.Actions++
+			result, err := action.Apply(ctx, opts.DryRun)
+			item := jsonAction{TaskID: task.ID, TaskName: task.Name, Summary: action.Summary, Result: result}
+			if err != nil {
+				report.Summary.Failed++
+				item.Error = err.Error()
+				report.Actions = append(report.Actions, item)
+				if opts.FailFast && !task.ContinueOnError {
+					stop = true
+					break
+				}
+				continue
+			}
+			switch result {
+			case ResultChange:
+				report.Summary.Changed++
+			case ResultSkip, ResultStop:
+				report.Summary.Skipped++
+			case ResultWarn:
+				report.Summary.Warnings++
+			}
+			report.Actions = append(report.Actions, item)
+			if result == ResultStop && !opts.DryRun {
+				break
+			}
+		}
+		if stop {
+			break
+		}
+	}
+	if err := json.NewEncoder(w).Encode(report); err != nil {
+		return err
+	}
+	if report.Summary.Failed > 0 {
+		return errors.New("one or more tasks failed")
+	}
+	return nil
+}
+
+type colorCode string
+
+const (
+	colorBold  colorCode = "\033[1m"
+	colorGreen colorCode = "\033[32m"
+	colorRed   colorCode = "\033[31m"
+)
+
+func (e *Engine) color(s string, code colorCode) string {
+	if !e.colorEnabled() {
+		return s
+	}
+	return string(code) + s + "\033[0m"
+}
+
+func (e *Engine) colorEnabled() bool {
+	return e.Runtime == nil || e.Runtime.Getenv == nil || e.Runtime.Getenv("NO_COLOR") == ""
+}
+
+func (e *Engine) prepareSudo(ctx context.Context, tasks []*Task) error {
+	if e.Runtime == nil || !e.Runtime.NeedsSudo() {
+		return nil
+	}
+	if !slices.ContainsFunc(tasks, func(task *Task) bool { return task.RequiresSudo }) {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "sudo", "-v")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return fmt.Errorf("sudo authentication failed: %w", err)
+		}
+		return fmt.Errorf("sudo authentication failed: %w:\n%s", err, msg)
+	}
+	return nil
+}
+
+// Selected returns tasks matching selection, topologically sorted.
+func (e *Engine) Selected(selection Selection) ([]*Task, error) {
+	tasks := slices.Clone(e.Tasks)
+	taskIDs := make(map[string]bool)
+	for _, task := range tasks {
+		taskIDs[task.ID] = true
+	}
+	var unknown []string
+	for _, id := range append(slices.Clone(selection.Only), selection.Skip...) {
+		if !taskIDs[id] {
+			unknown = append(unknown, id)
+		}
+	}
+	if len(unknown) > 0 {
+		slices.Sort(unknown)
+		unknown = slices.Compact(unknown)
+		return nil, fmt.Errorf("unknown task id(s): %s", strings.Join(unknown, ", "))
+	}
+	if len(selection.Only) > 0 {
+		tasks = slices.DeleteFunc(tasks, func(task *Task) bool {
+			return !slices.Contains(selection.Only, task.ID)
+		})
+	}
+	if len(selection.Skip) > 0 {
+		tasks = slices.DeleteFunc(tasks, func(task *Task) bool {
+			return slices.Contains(selection.Skip, task.ID)
+		})
+	}
+	if len(selection.Tags) > 0 {
+		tasks = slices.DeleteFunc(tasks, func(task *Task) bool {
+			return !task.hasAnyTag(selection.Tags)
+		})
+	}
+	if len(tasks) == 0 {
+		return nil, errors.New("no tasks selected")
+	}
+	return SortTasks(tasks)
+}
+
+// SortTasks topologically sorts tasks based on their DependsOn field.
+func SortTasks(tasks []*Task) ([]*Task, error) {
+	inDegree := make(map[string]int)
+	graph := make(map[string][]*Task)
+	taskMap := make(map[string]*Task)
+
+	for _, t := range tasks {
+		taskMap[t.ID] = t
+		inDegree[t.ID] = 0
+	}
+
+	for _, t := range tasks {
+		for _, dep := range t.DependsOn {
+			if _, ok := taskMap[dep]; ok {
+				graph[dep] = append(graph[dep], t)
+				inDegree[t.ID]++
+			}
+		}
+	}
+
+	var zeroInDegree []*Task
+	for _, t := range tasks {
+		if inDegree[t.ID] == 0 {
+			zeroInDegree = append(zeroInDegree, t)
+		}
+	}
+
+	var sorted []*Task
+	for len(zeroInDegree) > 0 {
+		n := zeroInDegree[0]
+		zeroInDegree = zeroInDegree[1:]
+		sorted = append(sorted, n)
+
+		for _, m := range graph[n.ID] {
+			inDegree[m.ID]--
+			if inDegree[m.ID] == 0 {
+				zeroInDegree = append(zeroInDegree, m)
+			}
+		}
+	}
+
+	if len(sorted) != len(tasks) {
+		return nil, errors.New("cycle detected in task dependencies")
+	}
+
+	return sorted, nil
+}
+
+func (task *Task) hasAnyTag(tags []string) bool {
+	for _, tag := range tags {
+		if slices.Contains(task.Tags, tag) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Engine) starlarkTask(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		id              string
+		name            string
+		tags            *starlark.List
+		dependsOn       *starlark.List
+		continueOnError bool
+		requiresSudo    bool
+		run             starlark.Callable
+		when            bool = true
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"id", &id,
+		"name", &name,
+		"run", &run,
+		"tags?", &tags,
+		"depends_on?", &dependsOn,
+		"continue_on_error?", &continueOnError,
+		"requires_sudo?", &requiresSudo,
+		"when?", &when,
+	); err != nil {
+		return nil, err
+	}
+	if !when {
+		return starlark.None, nil
+	}
+	if id == "" {
+		return nil, fmt.Errorf("%s: id cannot be empty", b.Name())
+	}
+	if run == nil {
+		return nil, fmt.Errorf("%s: run is required", b.Name())
+	}
+
+	var tagStrings []string
+	if tags != nil {
+		for i := range tags.Len() {
+			tag, ok := starlark.AsString(tags.Index(i))
+			if !ok {
+				return nil, fmt.Errorf("%s: tags[%d] is not a string", b.Name(), i)
+			}
+			tagStrings = append(tagStrings, tag)
+		}
+	}
+
+	var depsStrings []string
+	if dependsOn != nil {
+		for i := range dependsOn.Len() {
+			dep, ok := starlark.AsString(dependsOn.Index(i))
+			if !ok {
+				return nil, fmt.Errorf("%s: depends_on[%d] is not a string", b.Name(), i)
+			}
+			depsStrings = append(depsStrings, dep)
+		}
+	}
+
+	if slices.ContainsFunc(e.Tasks, func(task *Task) bool { return task.ID == id }) {
+		return nil, fmt.Errorf("%s: duplicate task id %q", b.Name(), id)
+	}
+
+	e.Tasks = append(e.Tasks, &Task{
+		ID:              id,
+		Name:            name,
+		Tags:            tagStrings,
+		DependsOn:       depsStrings,
+		ContinueOnError: continueOnError,
+		RequiresSudo:    requiresSudo,
+		Run:             run,
+	})
+	return starlark.None, nil
+}

--- a/cmd/boot/internal/engine_test.go
+++ b/cmd/boot/internal/engine_test.go
@@ -1,0 +1,299 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package internal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+func TestSortTasks(t *testing.T) {
+	tasks := []*Task{
+		{ID: "C", DependsOn: []string{"A"}},
+		{ID: "A"},
+		{ID: "B", DependsOn: []string{"A"}},
+		{ID: "D", DependsOn: []string{"B", "C"}},
+	}
+
+	sorted, err := SortTasks(tasks)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ids []string
+	for _, task := range sorted {
+		ids = append(ids, task.ID)
+	}
+
+	// A must be first. D must be last. C and B can be in any order.
+	if ids[0] != "A" {
+		t.Errorf("expected A to be first, got %s", ids[0])
+	}
+	if ids[3] != "D" {
+		t.Errorf("expected D to be last, got %s", ids[3])
+	}
+}
+
+func TestSelectedRejectsUnknownTasks(t *testing.T) {
+	engine := &Engine{Tasks: []*Task{{ID: "known"}}}
+	_, err := engine.Selected(Selection{Only: []string{"missing"}})
+	if err == nil || err.Error() != "unknown task id(s): missing" {
+		t.Fatalf("error = %v, want unknown task error", err)
+	}
+}
+
+func TestSelectedRejectsEmptySelection(t *testing.T) {
+	engine := &Engine{Tasks: []*Task{{ID: "known", Tags: []string{"one"}}}}
+	_, err := engine.Selected(Selection{Tags: []string{"missing"}})
+	if err == nil || err.Error() != "no tasks selected" {
+		t.Fatalf("error = %v, want no tasks selected", err)
+	}
+}
+
+func TestPlanFailFastStopsAfterActionFailure(t *testing.T) {
+	var ranSecond bool
+	engine := &Engine{Tasks: []*Task{
+		{
+			ID:   "first",
+			Name: "first",
+			Run: starlark.NewBuiltin("first", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+				AddAction(thread, Action{
+					Summary: "fail",
+					Apply: func(context.Context, bool) (Result, error) {
+						return "", errors.New("boom")
+					},
+				})
+				return starlark.None, nil
+			}),
+		},
+		{
+			ID:   "second",
+			Name: "second",
+			Run: starlark.NewBuiltin("second", func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+				ranSecond = true
+				return starlark.None, nil
+			}),
+		},
+	}}
+
+	var out bytes.Buffer
+	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{DryRun: true, FailFast: true})
+	if err == nil {
+		t.Fatal("Run succeeded, want failure")
+	}
+	if ranSecond {
+		t.Fatal("second task ran after action failure")
+	}
+}
+
+func TestApplyVerboseFailFastStopsAfterActionFailure(t *testing.T) {
+	var ranSecond bool
+	engine := &Engine{Tasks: []*Task{
+		{
+			ID:   "first",
+			Name: "first",
+			Run: starlark.NewBuiltin("first", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+				AddAction(thread, Action{
+					Summary: "fail",
+					Apply: func(context.Context, bool) (Result, error) {
+						return "", errors.New("boom")
+					},
+				})
+				return starlark.None, nil
+			}),
+		},
+		{
+			ID:   "second",
+			Name: "second",
+			Run: starlark.NewBuiltin("second", func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+				ranSecond = true
+				return starlark.None, nil
+			}),
+		},
+	}}
+
+	var out bytes.Buffer
+	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{Verbose: true, FailFast: true})
+	if err == nil {
+		t.Fatal("Run succeeded, want failure")
+	}
+	if ranSecond {
+		t.Fatal("second task ran after action failure")
+	}
+}
+
+func TestApplyFailFastPreservesContinueOnError(t *testing.T) {
+	var ranSecond bool
+	engine := &Engine{Tasks: []*Task{
+		{
+			ID:              "first",
+			Name:            "first",
+			ContinueOnError: true,
+			Run: starlark.NewBuiltin("first", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+				AddAction(thread, Action{
+					Summary: "fail",
+					Apply: func(context.Context, bool) (Result, error) {
+						return "", errors.New("boom")
+					},
+				})
+				return starlark.None, nil
+			}),
+		},
+		{
+			ID:   "second",
+			Name: "second",
+			Run: starlark.NewBuiltin("second", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+				ranSecond = true
+				AddAction(thread, Action{
+					Summary: "ok",
+					Apply: func(context.Context, bool) (Result, error) {
+						return ResultSkip, nil
+					},
+				})
+				return starlark.None, nil
+			}),
+		},
+	}}
+
+	var out bytes.Buffer
+	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{FailFast: true, Concurrency: 1})
+	if err == nil {
+		t.Fatal("Run succeeded, want failure report")
+	}
+	if !ranSecond {
+		t.Fatal("second task did not run after continuable failure")
+	}
+	if !strings.Contains(out.String(), "1 action failed") {
+		t.Fatalf("output does not report the continuable failure:\n%s", out.String())
+	}
+}
+
+func TestApplyStopsCurrentTaskOnResultStop(t *testing.T) {
+	var ranSecondAction bool
+	engine := &Engine{Tasks: []*Task{
+		{
+			ID:   "first",
+			Name: "first",
+			Run: starlark.NewBuiltin("first", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+				AddAction(thread, Action{
+					Summary: "stop",
+					Apply: func(context.Context, bool) (Result, error) {
+						return ResultStop, nil
+					},
+				})
+				AddAction(thread, Action{
+					Summary: "must not run",
+					Apply: func(context.Context, bool) (Result, error) {
+						ranSecondAction = true
+						return ResultChange, nil
+					},
+				})
+				return starlark.None, nil
+			}),
+		},
+	}}
+
+	var out bytes.Buffer
+	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{Concurrency: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ranSecondAction {
+		t.Fatal("second action ran after ResultStop")
+	}
+}
+
+func TestPlanDoesNotStopOnResultStop(t *testing.T) {
+	var ranSecondAction bool
+	engine := &Engine{Tasks: []*Task{
+		{
+			ID:   "first",
+			Name: "first",
+			Run: starlark.NewBuiltin("first", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+				AddAction(thread, Action{
+					Summary: "stop",
+					Apply: func(context.Context, bool) (Result, error) {
+						return ResultStop, nil
+					},
+				})
+				AddAction(thread, Action{
+					Summary: "still plan",
+					Apply: func(context.Context, bool) (Result, error) {
+						ranSecondAction = true
+						return ResultSkip, nil
+					},
+				})
+				return starlark.None, nil
+			}),
+		},
+	}}
+
+	var out bytes.Buffer
+	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ranSecondAction {
+		t.Fatal("plan stopped after ResultStop")
+	}
+}
+
+func TestTaskRequiresSudo(t *testing.T) {
+	engine := &Engine{}
+	run := starlark.NewBuiltin("run", func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+		return starlark.None, nil
+	})
+
+	_, err := engine.starlarkTask(nil, starlark.NewBuiltin("task", engine.starlarkTask), nil, []starlark.Tuple{
+		{starlark.String("id"), starlark.String("root_task")},
+		{starlark.String("name"), starlark.String("Root task")},
+		{starlark.String("run"), run},
+		{starlark.String("requires_sudo"), starlark.True},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !engine.Tasks[0].RequiresSudo {
+		t.Fatal("RequiresSudo is false, want true")
+	}
+}
+
+func TestFailBuiltin(t *testing.T) {
+	_, err := fail(nil, starlark.NewBuiltin("fail", fail), starlark.Tuple{starlark.String("unsupported machine")}, nil)
+	if err == nil {
+		t.Fatal("fail succeeded, want error")
+	}
+	if err.Error() != "unsupported machine" {
+		t.Fatalf("error = %q, want %q", err, "unsupported machine")
+	}
+}
+
+func TestPrepareSudo(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("sudo is not needed when running as root")
+	}
+	bin := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "sudo-ran")
+	if err := os.WriteFile(filepath.Join(bin, "sudo"), []byte("#!/bin/sh\ntouch "+marker+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	engine := &Engine{Runtime: &Runtime{Getenv: func(string) string { return "" }}}
+	err := engine.prepareSudo(context.Background(), []*Task{{ID: "root_task", RequiresSudo: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("sudo was not called: %v", err)
+	}
+}

--- a/cmd/boot/internal/env/env.go
+++ b/cmd/boot/internal/env/env.go
@@ -1,0 +1,128 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package env
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark env module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "env" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"command_exists": starlark.NewBuiltin("env.command_exists", m.commandExists),
+		"get":            starlark.NewBuiltin("env.get", m.get),
+		"hostname":       starlark.NewBuiltin("env.hostname", m.hostname),
+		"load_dir":       starlark.NewBuiltin("env.load_dir", m.loadDir),
+	}
+}
+
+func (m *impl) commandExists(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "name", &name); err != nil {
+		return nil, err
+	}
+	_, err := exec.LookPath(name)
+	return starlark.Bool(err == nil), nil
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) get(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		key        string
+		defaultVal string
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"key", &key,
+		"default?", &defaultVal,
+	); err != nil {
+		return nil, err
+	}
+
+	val := m.rt.Getenv(key)
+	if val == "" {
+		val = os.Getenv(key)
+	}
+	if val == "" {
+		val = defaultVal
+	}
+	return starlark.String(val), nil
+}
+
+func (m *impl) hostname(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs); err != nil {
+		return nil, err
+	}
+
+	name, err := m.rt.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	return starlark.String(name), nil
+}
+
+func (m *impl) loadDir(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	dir := m.rt.ResolveSource(path)
+	matches, err := filepath.Glob(filepath.Join(dir, "*.conf"))
+	if err != nil {
+		return nil, err
+	}
+	for _, match := range matches {
+		if err := loadFile(match); err != nil {
+			return nil, fmt.Errorf("%s: %w", match, err)
+		}
+	}
+	return starlark.None, nil
+}
+
+func loadFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		value = os.Expand(value, func(name string) string {
+			return os.Getenv(name)
+		})
+		if err := os.Setenv(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/boot/internal/env/env_test.go
+++ b/cmd/boot/internal/env/env_test.go
@@ -1,0 +1,123 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+func TestGet(t *testing.T) {
+	rt := &boot.Runtime{
+		Getenv: func(key string) string {
+			if key == "FOO" {
+				return "bar"
+			}
+			return ""
+		},
+	}
+
+	m := Module()
+	members := m.Members(rt)
+	get, ok := members["get"].(*starlark.Builtin)
+	if !ok {
+		t.Fatal("env.get is not a builtin")
+	}
+
+	cases := map[string]struct {
+		args    starlark.Tuple
+		kwargs  []starlark.Tuple
+		want    string
+		wantErr string
+	}{
+		"exists": {
+			args: starlark.Tuple{starlark.String("FOO")},
+			want: "bar",
+		},
+		"missing": {
+			args: starlark.Tuple{starlark.String("BAR")},
+			want: "",
+		},
+		"missing with default": {
+			args: starlark.Tuple{starlark.String("BAR"), starlark.String("baz")},
+			want: "baz",
+		},
+		"missing with default kwarg": {
+			args:   starlark.Tuple{starlark.String("BAR")},
+			kwargs: []starlark.Tuple{{starlark.String("default"), starlark.String("qux")}},
+			want:   "qux",
+		},
+		"too many args": {
+			args:    starlark.Tuple{starlark.String("FOO"), starlark.String("bar"), starlark.String("baz")},
+			wantErr: "env.get: got 3 arguments, want at most 2",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			thread := &starlark.Thread{Name: "test"}
+			got, err := get.CallInternal(thread, tc.args, tc.kwargs)
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("got error %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.String() != `"`+tc.want+`"` {
+				t.Fatalf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHostname(t *testing.T) {
+	m := Module()
+	members := m.Members(&boot.Runtime{})
+	hostname, ok := members["hostname"].(*starlark.Builtin)
+	if !ok {
+		t.Fatal("env.hostname is not a builtin")
+	}
+
+	got, err := hostname.CallInternal(&starlark.Thread{Name: "test"}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == starlark.String("") {
+		t.Fatal("env.hostname returned empty string")
+	}
+}
+
+func TestLoadDir(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "environment.d")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "10-base.conf"), []byte("BASE=$HOME/base\nQUOTED=\"$BASE/quoted\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", "/home/test")
+
+	rt := &boot.Runtime{Root: root}
+	members := Module().Members(rt)
+	loadDir := members["load_dir"].(*starlark.Builtin)
+	if _, err := loadDir.CallInternal(&starlark.Thread{Name: "test"}, starlark.Tuple{starlark.String("environment.d")}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("BASE"); got != "/home/test/base" {
+		t.Fatalf("BASE = %q, want /home/test/base", got)
+	}
+	if got := os.Getenv("QUOTED"); got != "/home/test/base/quoted" {
+		t.Fatalf("QUOTED = %q, want /home/test/base/quoted", got)
+	}
+}

--- a/cmd/boot/internal/fetch/doc.go
+++ b/cmd/boot/internal/fetch/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package fetch provides boot Starlark primitives for downloading files.
+package fetch

--- a/cmd/boot/internal/fetch/fetch.go
+++ b/cmd/boot/internal/fetch/fetch.go
@@ -1,0 +1,169 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package fetch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark fetch module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "fetch" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"file": starlark.NewBuiltin("fetch.file", m.file),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) file(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		url      string
+		path     string
+		mode     int = 0o644
+		checksum string
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"url", &url,
+		"path", &path,
+		"mode?", &mode,
+		"checksum?", &checksum,
+	); err != nil {
+		return nil, err
+	}
+	abs := m.rt.ResolveTarget(path)
+	checksum = normalizeChecksum(checksum)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("fetch %s to %s", url, abs),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			ok, err := fileMatches(abs, checksum)
+			if err != nil {
+				return "", err
+			}
+			if ok {
+				return boot.ResultSkip, nil
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if err := download(ctx, url, abs, os.FileMode(mode)); err != nil {
+				return "", err
+			}
+			if checksum != "" {
+				ok, err := fileMatches(abs, checksum)
+				if err != nil {
+					return "", err
+				}
+				if !ok {
+					return "", fmt.Errorf("checksum mismatch for %s", abs)
+				}
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func normalizeChecksum(checksum string) string {
+	return strings.TrimPrefix(strings.TrimSpace(checksum), "sha256:")
+}
+
+func fileMatches(path, checksum string) (bool, error) {
+	if checksum == "" {
+		_, err := os.Stat(path)
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return err == nil, err
+	}
+	got, err := fileSHA256(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return got == checksum, nil
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func download(ctx context.Context, url, path string, mode os.FileMode) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("download failed: %s", resp.Status)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/cmd/boot/internal/fetch/fetch_test.go
+++ b/cmd/boot/internal/fetch/fetch_test.go
@@ -1,0 +1,78 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package fetch
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+
+	"go.starlark.net/starlark"
+)
+
+func TestFetchFile(t *testing.T) {
+	content := []byte("hello\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(content)
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+	path := filepath.Join(root, "dir", "file.txt")
+	checksum := fmt.Sprintf("%x", sha256.Sum256(content))
+	_, err := m.file(thread, starlark.NewBuiltin("fetch.file", m.file), nil, []starlark.Tuple{
+		{starlark.String("url"), starlark.String(server.URL)},
+		{starlark.String("path"), starlark.String(path)},
+		{starlark.String("mode"), starlark.MakeInt(0o600)},
+		{starlark.String("checksum"), starlark.String(checksum)},
+	})
+	if err != nil {
+		t.Fatalf("fetch.file failed: %v", err)
+	}
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("got content %q, want %q", got, content)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("got mode %o, want 0600", info.Mode().Perm())
+	}
+
+	res, err = task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}

--- a/cmd/boot/internal/flatpak/flatpak.go
+++ b/cmd/boot/internal/flatpak/flatpak.go
@@ -1,0 +1,75 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package flatpak
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark flatpak module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "flatpak" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"update": starlark.NewBuiltin("flatpak.update", m.update),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) update(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs); err != nil {
+		return nil, err
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: "update flatpak applications",
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if _, err := exec.LookPath("flatpak"); err != nil {
+				return boot.ResultSkip, nil
+			}
+			cmd := exec.CommandContext(ctx, "flatpak", "remote-ls", "--updates")
+			out, err := cmd.Output()
+			if err != nil {
+				return "", err
+			}
+			if len(bytes.TrimSpace(out)) == 0 {
+				return boot.ResultSkip, nil
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			cmd = exec.CommandContext(ctx, "flatpak", "update", "-y")
+			out, err = cmd.CombinedOutput()
+			if err != nil {
+				msg := strings.TrimSpace(string(out))
+				if msg == "" {
+					return "", err
+				}
+				return "", fmt.Errorf("%w:\n%s", err, msg)
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}

--- a/cmd/boot/internal/fs/doc.go
+++ b/cmd/boot/internal/fs/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package fs provides boot Starlark primitives for idempotent filesystem changes.
+package fs

--- a/cmd/boot/internal/fs/fs.go
+++ b/cmd/boot/internal/fs/fs.go
@@ -1,0 +1,457 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package fs
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark fs module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "fs" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"chmod":     starlark.NewBuiltin("fs.chmod", m.chmod),
+		"dir":       starlark.NewBuiltin("fs.dir", m.dir),
+		"symlink":   starlark.NewBuiltin("fs.symlink", m.symlink),
+		"file":      starlark.NewBuiltin("fs.file", m.file),
+		"newer":     starlark.NewBuiltin("fs.newer", m.newer),
+		"remove":    starlark.NewBuiltin("fs.remove", m.remove),
+		"sha256":    starlark.NewBuiltin("fs.sha256", m.sha256),
+		"sync_tree": starlark.NewBuiltin("fs.sync_tree", m.syncTree),
+		"template":  starlark.NewBuiltin("fs.template", m.template),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) chmod(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		path string
+		mode int
+	)
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path, "mode", &mode); err != nil {
+		return nil, err
+	}
+	abs := m.rt.ResolveTarget(path)
+	targetMode := os.FileMode(mode)
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("chmod %04o %s", targetMode.Perm(), abs),
+		Apply: func(_ context.Context, dryRun bool) (boot.Result, error) {
+			info, err := os.Stat(abs)
+			if err != nil {
+				return "", err
+			}
+			if info.Mode().Perm() == targetMode.Perm() {
+				return boot.ResultSkip, nil
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if err := os.Chmod(abs, targetMode); err != nil {
+				return "", err
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func (m *impl) remove(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var path string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	abs := m.rt.ResolveTarget(path)
+	boot.AddAction(thread, boot.Action{
+		Summary: "remove " + abs,
+		Apply: func(_ context.Context, dryRun bool) (boot.Result, error) {
+			_, err := os.Lstat(abs)
+			if errors.Is(err, fs.ErrNotExist) {
+				return boot.ResultSkip, nil
+			}
+			if err != nil {
+				return "", err
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if err := os.RemoveAll(abs); err != nil {
+				return "", err
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func (m *impl) syncTree(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		source       string
+		target       string
+		owner        string
+		group        string
+		sudo         bool
+		onlyIfExists bool
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"source", &source,
+		"target", &target,
+		"owner?", &owner,
+		"group?", &group,
+		"sudo?", &sudo,
+		"only_if_exists?", &onlyIfExists,
+	); err != nil {
+		return nil, err
+	}
+
+	src := m.rt.ResolveSource(source)
+	dst := m.rt.ResolveTarget(target)
+	summary := fmt.Sprintf("sync tree %s to %s", src, dst)
+	if owner != "" || group != "" {
+		summary += fmt.Sprintf(" (owner %s:%s)", owner, group)
+	}
+	if sudo {
+		summary += " (sudo)"
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: summary,
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if _, err := os.Stat(src); errors.Is(err, fs.ErrNotExist) && onlyIfExists {
+				return boot.ResultSkip, nil
+			} else if err != nil {
+				return "", err
+			}
+			if dryRun && sudo && m.rt.NeedsSudo() {
+				return boot.ResultChange, nil
+			}
+
+			args := []string{"-a"}
+			if owner != "" || group != "" {
+				args = append(args, "--chown="+owner+":"+group)
+			}
+			checkArgs := append([]string{"-ani"}, args[1:]...)
+			checkArgs = append(checkArgs, withTrailingSeparator(src), withTrailingSeparator(dst))
+			checkCmd := rsyncCommand(ctx, m.rt, sudo, checkArgs)
+			out, err := checkCmd.CombinedOutput()
+			if err != nil {
+				return "", boot.CommandError(checkCmd.Args, out, err)
+			}
+			if len(bytes.TrimSpace(out)) == 0 {
+				return boot.ResultSkip, nil
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+
+			args = append(args, withTrailingSeparator(src), withTrailingSeparator(dst))
+			cmd := rsyncCommand(ctx, m.rt, sudo, args)
+			out, err = cmd.CombinedOutput()
+			if err != nil {
+				return "", boot.CommandError(cmd.Args, out, err)
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func withTrailingSeparator(path string) string {
+	if strings.HasSuffix(path, string(os.PathSeparator)) {
+		return path
+	}
+	return path + string(os.PathSeparator)
+}
+
+func rsyncCommand(ctx context.Context, rt *boot.Runtime, sudo bool, args []string) *exec.Cmd {
+	if sudo && rt.NeedsSudo() {
+		return exec.CommandContext(ctx, "sudo", append([]string{"rsync"}, args...)...)
+	}
+	return exec.CommandContext(ctx, "rsync", args...)
+}
+
+func (m *impl) file(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		path    string
+		content string
+		mode    int = 0o644
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"path", &path,
+		"content", &content,
+		"mode?", &mode,
+	); err != nil {
+		return nil, err
+	}
+	abs := m.rt.ResolveTarget(path)
+	boot.AddAction(thread, boot.Action{
+		Summary: "file " + abs,
+		Apply: func(_ context.Context, dryRun bool) (boot.Result, error) {
+			targetMode := os.FileMode(mode)
+
+			info, err := os.Stat(abs)
+			if err == nil {
+				got, err2 := os.ReadFile(abs)
+				if err2 == nil && string(got) == content && info.Mode().Perm() == targetMode.Perm() {
+					return boot.ResultSkip, nil
+				}
+			}
+
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+				return "", err
+			}
+			if err := os.WriteFile(abs, []byte(content), targetMode); err != nil {
+				return "", err
+			}
+			if err := os.Chmod(abs, targetMode); err != nil {
+				return "", err
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func (m *impl) template(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		path   string
+		text   string
+		values *starlark.Dict
+		mode   int = 0o644
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"path", &path,
+		"template", &text,
+		"values", &values,
+		"mode?", &mode,
+	); err != nil {
+		return nil, err
+	}
+	content, err := renderTemplate(text, values)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", b.Name(), err)
+	}
+	return m.file(thread, starlark.NewBuiltin("fs.file", m.file), nil, []starlark.Tuple{
+		{starlark.String("path"), starlark.String(path)},
+		{starlark.String("content"), starlark.String(content)},
+		{starlark.String("mode"), starlark.MakeInt(mode)},
+	})
+}
+
+func renderTemplate(text string, values *starlark.Dict) (string, error) {
+	for _, key := range values.Keys() {
+		name, ok := starlark.AsString(key)
+		if !ok {
+			return "", fmt.Errorf("template value key %s is not a string", key)
+		}
+		value, _, _ := values.Get(key)
+		replacement, ok := starlark.AsString(value)
+		if !ok {
+			replacement = value.String()
+		}
+		text = strings.ReplaceAll(text, "{{"+name+"}}", replacement)
+	}
+	return text, nil
+}
+
+func (m *impl) sha256(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	f, err := os.Open(m.rt.ResolveTarget(path))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return starlark.String(hex.EncodeToString(h.Sum(nil))), nil
+}
+
+func (m *impl) newer(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var source, target string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "source", &source, "target", &target); err != nil {
+		return nil, err
+	}
+	src, err := os.Stat(m.rt.ResolveTarget(source))
+	if err != nil {
+		return nil, err
+	}
+	dst, err := os.Stat(m.rt.ResolveTarget(target))
+	if errors.Is(err, fs.ErrNotExist) {
+		return starlark.True, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return starlark.Bool(src.ModTime().After(dst.ModTime())), nil
+}
+
+func (m *impl) dir(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var path string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "path", &path); err != nil {
+		return nil, err
+	}
+	abs := m.rt.ResolveTarget(path)
+	boot.AddAction(thread, boot.Action{
+		Summary: "dir " + abs,
+		Apply: func(_ context.Context, dryRun bool) (boot.Result, error) {
+			info, err := os.Stat(abs)
+			switch {
+			case err == nil && info.IsDir():
+				return boot.ResultSkip, nil
+			case err == nil:
+				return "", fmt.Errorf("exists and is not a directory")
+			case !errors.Is(err, fs.ErrNotExist):
+				return "", err
+			case dryRun:
+				return boot.ResultChange, nil
+			default:
+				return boot.ResultChange, os.MkdirAll(abs, 0o755)
+			}
+		},
+	})
+	return starlark.None, nil
+}
+
+func (m *impl) symlink(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		source string
+		target string
+		backup bool
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"source", &source,
+		"target", &target,
+		"backup?", &backup,
+	); err != nil {
+		return nil, err
+	}
+	src := m.rt.ResolveSource(source)
+	dst := m.rt.ResolveTarget(target)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("symlink %s -> %s", dst, src),
+		Apply: func(_ context.Context, dryRun bool) (boot.Result, error) {
+			info, err := os.Lstat(dst)
+			if errors.Is(err, fs.ErrNotExist) {
+				info = nil
+			} else if err != nil {
+				return "", err
+			}
+			if info != nil && info.Mode()&os.ModeSymlink != 0 {
+				link, err := os.Readlink(dst)
+				if err != nil {
+					return "", err
+				}
+				if link == src {
+					return boot.ResultSkip, nil
+				}
+			}
+
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				return "", err
+			}
+			if err := replacePath(dst, backup); err != nil {
+				return "", err
+			}
+			return boot.ResultChange, os.Symlink(src, dst)
+		},
+	})
+	return starlark.None, nil
+}
+
+func replacePath(path string, backup bool) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if backup {
+		return os.Rename(path, backupPath(path))
+	}
+	if info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+		return os.RemoveAll(path)
+	}
+	return os.Remove(path)
+}
+
+func backupPath(path string) string {
+	stamp := time.Now().UTC().Format("20060102T150405Z")
+	candidate := path + ".backup-" + stamp
+	for i := 2; ; i++ {
+		if _, err := os.Lstat(candidate); errors.Is(err, fs.ErrNotExist) {
+			return candidate
+		}
+		candidate = fmt.Sprintf("%s.backup-%s-%d", path, stamp, i)
+	}
+}

--- a/cmd/boot/internal/fs/fs_test.go
+++ b/cmd/boot/internal/fs/fs_test.go
@@ -1,0 +1,344 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package fs
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+	"go.starlark.net/starlark"
+)
+
+func TestFSDir(t *testing.T) {
+	root := t.TempDir()
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+
+	dirPath := filepath.Join(root, "testdir")
+
+	// 1. Initial creation
+	_, err := m.dir(thread, starlark.NewBuiltin("fs.dir", m.dir), starlark.Tuple{starlark.String(dirPath)}, nil)
+	if err != nil {
+		t.Fatalf("fs.dir failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+
+	info, err := os.Stat(dirPath)
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected directory, got file")
+	}
+
+	// 2. Idempotency check
+	task.Actions = nil
+	_, err = m.dir(thread, starlark.NewBuiltin("fs.dir", m.dir), starlark.Tuple{starlark.String(dirPath)}, nil)
+	if err != nil {
+		t.Fatalf("fs.dir failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+
+	res, err = task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}
+
+func TestFSFile(t *testing.T) {
+	root := t.TempDir()
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+
+	filePath := filepath.Join(root, "testfile.txt")
+	content := "hello world"
+	mode := 0o600
+
+	// 1. Initial creation
+	kwargs := []starlark.Tuple{
+		{starlark.String("path"), starlark.String(filePath)},
+		{starlark.String("content"), starlark.String(content)},
+		{starlark.String("mode"), starlark.MakeInt(mode)},
+	}
+
+	_, err := m.file(thread, starlark.NewBuiltin("fs.file", m.file), nil, kwargs)
+	if err != nil {
+		t.Fatalf("fs.file failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+
+	gotContent, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(gotContent) != content {
+		t.Errorf("got content %q, want %q", gotContent, content)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+	if info.Mode().Perm() != os.FileMode(mode).Perm() {
+		t.Errorf("got mode %o, want %o", info.Mode().Perm(), os.FileMode(mode).Perm())
+	}
+
+	// 2. Idempotency check
+	task.Actions = nil
+	_, err = m.file(thread, starlark.NewBuiltin("fs.file", m.file), nil, kwargs)
+	if err != nil {
+		t.Fatalf("fs.file failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+
+	res, err = task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+
+	// 3. Change mode
+	newMode := 0o644
+	kwargs[2] = starlark.Tuple{starlark.String("mode"), starlark.MakeInt(newMode)}
+	task.Actions = nil
+	_, err = m.file(thread, starlark.NewBuiltin("fs.file", m.file), nil, kwargs)
+	if err != nil {
+		t.Fatalf("fs.file failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+
+	res, err = task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+
+	info, err = os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+	if info.Mode().Perm() != os.FileMode(newMode).Perm() {
+		t.Errorf("got mode %o, want %o", info.Mode().Perm(), os.FileMode(newMode).Perm())
+	}
+}
+
+func TestFSTemplate(t *testing.T) {
+	root := t.TempDir()
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+	m := &impl{rt: rt}
+
+	values := starlark.NewDict(1)
+	if err := values.SetKey(starlark.String("name"), starlark.String("boot")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := m.template(thread, starlark.NewBuiltin("fs.template", m.template), nil, []starlark.Tuple{
+		{starlark.String("path"), starlark.String("out.txt")},
+		{starlark.String("template"), starlark.String("hello {{name}}\n")},
+		{starlark.String("values"), values},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := task.Actions[0].Apply(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "out.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello boot\n" {
+		t.Fatalf("content = %q, want hello boot", got)
+	}
+}
+
+func TestFSChmod(t *testing.T) {
+	root := t.TempDir()
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+	filePath := filepath.Join(root, "testfile.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := m.chmod(thread, starlark.NewBuiltin("fs.chmod", m.chmod), nil, []starlark.Tuple{
+		{starlark.String("path"), starlark.String(filePath)},
+		{starlark.String("mode"), starlark.MakeInt(0o600)},
+	})
+	if err != nil {
+		t.Fatalf("fs.chmod failed: %v", err)
+	}
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("got mode %o, want 0600", info.Mode().Perm())
+	}
+
+	res, err = task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}
+
+func TestFSRemoveDanglingSymlink(t *testing.T) {
+	root := t.TempDir()
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+	linkPath := filepath.Join(root, "dangling")
+	if err := os.Symlink(filepath.Join(root, "missing"), linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := m.remove(thread, starlark.NewBuiltin("fs.remove", m.remove), starlark.Tuple{starlark.String(linkPath)}, nil)
+	if err != nil {
+		t.Fatalf("fs.remove failed: %v", err)
+	}
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+	if _, err := os.Lstat(linkPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("dangling symlink still exists: %v", err)
+	}
+}
+
+func TestFSSymlink(t *testing.T) {
+	root := t.TempDir()
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+
+	sourcePath := filepath.Join(root, "source.txt")
+	targetPath := filepath.Join(root, "target.txt")
+
+	if err := os.WriteFile(sourcePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Initial creation
+	kwargs := []starlark.Tuple{
+		{starlark.String("source"), starlark.String(sourcePath)},
+		{starlark.String("target"), starlark.String(targetPath)},
+	}
+
+	_, err := m.symlink(thread, starlark.NewBuiltin("fs.symlink", m.symlink), nil, kwargs)
+	if err != nil {
+		t.Fatalf("fs.symlink failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+
+	link, err := os.Readlink(targetPath)
+	if err != nil {
+		t.Fatalf("readlink failed: %v", err)
+	}
+	if link != sourcePath {
+		t.Errorf("got link %q, want %q", link, sourcePath)
+	}
+
+	// 2. Idempotency check
+	task.Actions = nil
+	_, err = m.symlink(thread, starlark.NewBuiltin("fs.symlink", m.symlink), nil, kwargs)
+	if err != nil {
+		t.Fatalf("fs.symlink failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+
+	res, err = task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}

--- a/cmd/boot/internal/git/git.go
+++ b/cmd/boot/internal/git/git.go
@@ -1,0 +1,267 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark git module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "git" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"clone": starlark.NewBuiltin("git.clone", m.clone),
+		"pull":  starlark.NewBuiltin("git.pull", m.pull),
+		"sync":  starlark.NewBuiltin("git.sync", m.sync),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) sync(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		url  string
+		dest string
+	)
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "url", &url, "dest", &dest); err != nil {
+		return nil, err
+	}
+
+	dst := m.rt.ResolveTarget(dest)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("git sync %s to %s", url, dst),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if _, err := os.Stat(filepath.Join(dst, ".git")); errors.Is(err, fs.ErrNotExist) {
+				if dryRun {
+					return boot.ResultChange, nil
+				}
+				if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+					return "", err
+				}
+				cmd := exec.CommandContext(ctx, "git", "clone", url, dst)
+				if err := run(cmd); err != nil {
+					return "", err
+				}
+				return boot.ResultChange, nil
+			}
+
+			cmd := exec.CommandContext(ctx, "git", "-C", dst, "status", "--porcelain")
+			out, err := cmd.Output()
+			if err != nil {
+				return "", err
+			}
+			if len(out) > 0 {
+				return boot.ResultSkip, nil
+			}
+
+			if !hasUpstream(ctx, dst) {
+				return boot.ResultSkip, nil
+			}
+
+			if dryRun {
+				current, upstream, err := gitRevisions(ctx, dst)
+				if err != nil {
+					return "", err
+				}
+				if current == upstream {
+					return boot.ResultSkip, nil
+				}
+				return boot.ResultChange, nil
+			}
+
+			result, err := fastForward(ctx, dst)
+			if err != nil {
+				return "", err
+			}
+			return result, nil
+		},
+	})
+
+	return starlark.None, nil
+}
+
+func (m *impl) pull(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var dest string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "dest", &dest); err != nil {
+		return nil, err
+	}
+
+	dst := m.rt.ResolveTarget(dest)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("git pull %s", dst),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if _, err := os.Stat(filepath.Join(dst, ".git")); errors.Is(err, fs.ErrNotExist) {
+				return "", fmt.Errorf("not a git repository: %s", dst)
+			}
+
+			cmd := exec.CommandContext(ctx, "git", "-C", dst, "status", "--porcelain")
+			out, err := cmd.Output()
+			if err != nil {
+				return "", err
+			}
+			if len(out) > 0 {
+				return boot.ResultSkip, nil
+			}
+
+			if !hasUpstream(ctx, dst) {
+				return boot.ResultSkip, nil
+			}
+
+			if dryRun {
+				current, upstream, err := gitRevisions(ctx, dst)
+				if err != nil {
+					return "", err
+				}
+				if current == upstream {
+					return boot.ResultSkip, nil
+				}
+				return boot.ResultChange, nil
+			}
+
+			result, err := fastForward(ctx, dst)
+			if err != nil {
+				return "", err
+			}
+			return result, nil
+		},
+	})
+
+	return starlark.None, nil
+}
+
+func (m *impl) clone(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		url  string
+		dest string
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"url", &url,
+		"dest", &dest,
+	); err != nil {
+		return nil, err
+	}
+
+	dst := m.rt.ResolveTarget(dest)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("git clone %s to %s", url, dst),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {
+				return boot.ResultSkip, nil
+			}
+
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				return "", err
+			}
+
+			cmd := exec.CommandContext(ctx, "git", "clone", url, dst)
+			if err := run(cmd); err != nil {
+				return "", err
+			}
+
+			return boot.ResultChange, nil
+		},
+	})
+
+	return starlark.None, nil
+}
+
+func run(cmd *exec.Cmd) error {
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	msg := strings.TrimSpace(string(out))
+	if msg == "" {
+		return err
+	}
+	return fmt.Errorf("%w:\n%s", err, msg)
+}
+
+func hasUpstream(ctx context.Context, dst string) bool {
+	cmd := exec.CommandContext(ctx, "git", "-C", dst, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	return cmd.Run() == nil
+}
+
+func fastForward(ctx context.Context, dst string) (boot.Result, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dst, "fetch", "--prune", "origin")
+	if err := run(cmd); err != nil {
+		return "", err
+	}
+
+	current, upstream, err := gitRevisions(ctx, dst)
+	if err != nil {
+		return "", err
+	}
+	if current == upstream {
+		return boot.ResultSkip, nil
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "-C", dst, "pull", "--ff-only")
+	if err := run(cmd); err != nil {
+		return "", err
+	}
+
+	return boot.ResultChange, nil
+}
+
+func gitRevisions(ctx context.Context, dst string) (string, string, error) {
+	current, err := gitRevision(ctx, dst, "HEAD")
+	if err != nil {
+		return "", "", err
+	}
+	upstream, err := gitRevision(ctx, dst, "@{u}")
+	if err != nil {
+		return "", "", err
+	}
+	return current, upstream, nil
+}
+
+func gitRevision(ctx context.Context, dst, rev string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dst, "rev-parse", "--verify", rev)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/cmd/boot/internal/git/git_test.go
+++ b/cmd/boot/internal/git/git_test.go
@@ -1,0 +1,198 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package git
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+	"go.starlark.net/starlark"
+)
+
+func TestGitClone(t *testing.T) {
+	// Require git to be installed for tests.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	root := t.TempDir()
+
+	// Initialize a local git repository to serve as the "remote".
+	remote := filepath.Join(root, "remote")
+	if err := os.Mkdir(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, remote, "init", "--bare")
+
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+
+	// 1. Initial clone should result in Change.
+	dest := filepath.Join(root, "local")
+	_, err := m.clone(thread, starlark.NewBuiltin("git.clone", m.clone), starlark.Tuple{
+		starlark.String(remote),
+		starlark.String(dest),
+	}, nil)
+	if err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+	if _, err := os.Stat(filepath.Join(dest, ".git")); errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("destination .git directory was not created")
+	}
+
+	// 2. Second clone (idempotency check) should result in Skip.
+	task.Actions = nil
+	_, err = m.clone(thread, starlark.NewBuiltin("git.clone", m.clone), starlark.Tuple{
+		starlark.String(remote),
+		starlark.String(dest),
+	}, nil)
+	if err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+	res, err = task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}
+
+func TestGitSync(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote")
+	if err := os.Mkdir(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, remote, "init", "--bare")
+
+	work := filepath.Join(root, "work")
+	if err := os.Mkdir(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, work, "init")
+	testutil.RunGit(t, work, "config", "user.email", "test@example.com")
+	testutil.RunGit(t, work, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, work, "add", "README.md")
+	testutil.RunGit(t, work, "commit", "-m", "initial")
+	testutil.RunGit(t, work, "branch", "-M", "main")
+	testutil.RunGit(t, work, "remote", "add", "origin", remote)
+	testutil.RunGit(t, work, "push", "-u", "origin", "main")
+	testutil.RunGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+	m := &impl{rt: rt}
+
+	dest := filepath.Join(root, "local")
+	_, err := m.sync(thread, starlark.NewBuiltin("git.sync", m.sync), nil, []starlark.Tuple{
+		{starlark.String("url"), starlark.String(remote)},
+		{starlark.String("dest"), starlark.String(dest)},
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+	if _, err := os.Stat(filepath.Join(dest, ".git")); err != nil {
+		t.Fatalf("destination .git: %v", err)
+	}
+
+	res, err = task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}
+
+func TestGitPullAlreadyCurrent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote")
+	if err := os.Mkdir(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, remote, "init", "--bare")
+
+	work := filepath.Join(root, "work")
+	if err := os.Mkdir(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, work, "init")
+	testutil.RunGit(t, work, "config", "user.email", "test@example.com")
+	testutil.RunGit(t, work, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, work, "add", "README.md")
+	testutil.RunGit(t, work, "commit", "-m", "initial")
+	testutil.RunGit(t, work, "branch", "-M", "main")
+	testutil.RunGit(t, work, "remote", "add", "origin", remote)
+	testutil.RunGit(t, work, "push", "-u", "origin", "main")
+	testutil.RunGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	dest := filepath.Join(root, "local")
+	testutil.RunGit(t, root, "clone", remote, dest)
+
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+	m := &impl{rt: rt}
+
+	_, err := m.pull(thread, starlark.NewBuiltin("git.pull", m.pull), starlark.Tuple{starlark.String(dest)}, nil)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}

--- a/cmd/boot/internal/golang/doc.go
+++ b/cmd/boot/internal/golang/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package golang provides boot Starlark primitives for Go tool installation.
+package golang

--- a/cmd/boot/internal/golang/golang.go
+++ b/cmd/boot/internal/golang/golang.go
@@ -1,0 +1,398 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package golang
+
+import (
+	"context"
+	"debug/buildinfo"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.astrophena.name/base/request"
+	"go.astrophena.name/base/version"
+	"go.starlark.net/starlark"
+	modulepkg "golang.org/x/mod/module"
+	"golang.org/x/sync/errgroup"
+)
+
+var goProxyURL = "https://proxy.golang.org"
+
+// Module returns the Starlark go module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "go" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"install":       starlark.NewBuiltin("go.install", m.install),
+		"install_local": starlark.NewBuiltin("go.install_local", m.installLocal),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) install(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		packages *starlark.List
+		cwd      string
+		ldflags  string = "-s -w -buildid="
+		trimpath bool   = true
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"packages", &packages,
+		"cwd?", &cwd,
+		"ldflags?", &ldflags,
+		"trimpath?", &trimpath,
+	); err != nil {
+		return nil, err
+	}
+	names, err := boot.StringList("packages", packages)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", b.Name(), err)
+	}
+	if len(names) == 0 {
+		return starlark.None, nil
+	}
+	latest := newLatestCache(latestModules(names))
+	for _, name := range names {
+		addInstallAction(thread, m.rt, name, cwd, ldflags, trimpath, "", latest)
+	}
+	return starlark.None, nil
+}
+
+func (m *impl) installLocal(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		pkg            string
+		cwd            string
+		fallbackLatest bool   = true
+		ldflags        string = "-s -w -buildid="
+		trimpath       bool   = true
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"package", &pkg,
+		"cwd", &cwd,
+		"fallback_latest?", &fallbackLatest,
+		"ldflags?", &ldflags,
+		"trimpath?", &trimpath,
+	); err != nil {
+		return nil, err
+	}
+	addInstallAction(thread, m.rt, pkg, cwd, ldflags, trimpath, cwd, nil)
+	if fallbackLatest {
+		addInstallAction(thread, m.rt, pkg+"@latest", "", ldflags, trimpath, "!"+cwd, newLatestCache([]string{packagePath(pkg)}))
+	}
+	return starlark.None, nil
+}
+
+func addInstallAction(thread *starlark.Thread, rt *boot.Runtime, pkg, cwd, ldflags string, trimpath bool, condition string, latest *latestCache) {
+	args := []string{"install"}
+	if ldflags != "" {
+		args = append(args, "-ldflags="+ldflags)
+	}
+	if trimpath {
+		args = append(args, "-trimpath")
+	}
+	args = append(args, pkg)
+
+	summary := "go " + strings.Join(args, " ")
+	if cwd != "" {
+		summary += " (cwd " + rt.ResolveTarget(cwd) + ")"
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: summary,
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if condition != "" {
+				negated := strings.HasPrefix(condition, "!")
+				path := condition
+				if negated {
+					path = strings.TrimPrefix(path, "!")
+				}
+				_, err := os.Stat(rt.ResolveTarget(path))
+				exists := err == nil
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
+					return "", err
+				}
+				if negated == exists {
+					return boot.ResultSkip, nil
+				}
+			}
+			upToDate, err := installUpToDate(ctx, rt, pkg, cwd, latest)
+			if err != nil {
+				return "", err
+			}
+			if upToDate {
+				return boot.ResultSkip, nil
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			cmd := exec.CommandContext(ctx, "go", args...)
+			if cwd != "" {
+				cmd.Dir = rt.ResolveTarget(cwd)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				msg := strings.TrimSpace(string(out))
+				if msg == "" {
+					return "", err
+				}
+				return "", fmt.Errorf("%w:\n%s", err, msg)
+			}
+			return boot.ResultChange, nil
+		},
+	})
+}
+
+func installUpToDate(ctx context.Context, rt *boot.Runtime, pkg, cwd string, latest *latestCache) (bool, error) {
+	bin, err := binaryPath(ctx, pkg)
+	if err != nil {
+		return false, err
+	}
+	info, err := buildInfo(ctx, bin)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.Path != packagePath(pkg) {
+		return false, nil
+	}
+	if cwd != "" {
+		return localUpToDate(ctx, rt.ResolveTarget(cwd), info)
+	}
+	return proxyUpToDate(ctx, pkg, info, latest)
+}
+
+func binaryPath(ctx context.Context, pkg string) (string, error) {
+	name := pathBase(packagePath(pkg))
+	out, err := exec.CommandContext(ctx, "go", "env", "GOBIN", "GOPATH", "GOEXE").Output()
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	for len(lines) < 3 {
+		lines = append(lines, "")
+	}
+	if lines[0] != "" {
+		return filepath.Join(lines[0], name+lines[2]), nil
+	}
+	gopath := strings.Split(lines[1], string(os.PathListSeparator))[0]
+	if gopath == "" {
+		return "", fmt.Errorf("go env GOPATH is empty")
+	}
+	return filepath.Join(gopath, "bin", name+lines[2]), nil
+}
+
+func packagePath(pkg string) string {
+	path, _, _ := strings.Cut(pkg, "@")
+	return path
+}
+
+func pathBase(path string) string {
+	path = strings.TrimRight(path, "/")
+	i := strings.LastIndex(path, "/")
+	if i < 0 {
+		return path
+	}
+	return path[i+1:]
+}
+
+type goBuildInfo struct {
+	Path     string
+	Module   string
+	Version  string
+	Settings map[string]string
+}
+
+func buildInfo(_ context.Context, bin string) (goBuildInfo, error) {
+	info, err := buildinfo.ReadFile(bin)
+	if err != nil {
+		if _, statErr := os.Stat(bin); os.IsNotExist(statErr) {
+			return goBuildInfo{}, statErr
+		}
+		return goBuildInfo{}, nil
+	}
+	got := goBuildInfo{
+		Path:     info.Path,
+		Module:   info.Main.Path,
+		Version:  info.Main.Version,
+		Settings: make(map[string]string),
+	}
+	for _, setting := range info.Settings {
+		got.Settings[setting.Key] = setting.Value
+	}
+	return got, nil
+}
+
+func localUpToDate(ctx context.Context, cwd string, info goBuildInfo) (bool, error) {
+	head, err := output(ctx, cwd, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return false, nil
+	}
+	dirty, err := output(ctx, cwd, "git", "status", "--porcelain")
+	if err != nil {
+		return false, nil
+	}
+	return info.Settings["vcs.revision"] == head && info.Settings["vcs.modified"] == "false" && dirty == "", nil
+}
+
+func proxyUpToDate(ctx context.Context, pkg string, info goBuildInfo, latest *latestCache) (bool, error) {
+	if info.Module == "" || info.Version == "" {
+		return false, nil
+	}
+	_, version, hasVersion := strings.Cut(pkg, "@")
+	if hasVersion && version != "latest" {
+		return info.Version == version, nil
+	}
+	var (
+		latestInfo moduleInfo
+		err        error
+	)
+	if latest != nil {
+		latestInfo, err = latest.Get(ctx, info.Module)
+	} else {
+		latestInfo, err = latestModule(ctx, info.Module)
+	}
+	if err != nil {
+		return false, err
+	}
+	return info.Version == latestInfo.Version, nil
+}
+
+type moduleInfo struct {
+	Version string
+}
+
+func latestModule(ctx context.Context, module string) (moduleInfo, error) {
+	escaped, err := modulepkg.EscapePath(module)
+	if err != nil {
+		return moduleInfo{}, err
+	}
+	info, err := request.Make[moduleInfo](ctx, request.Params{
+		Method: http.MethodGet,
+		URL:    strings.TrimRight(goProxyURL, "/") + "/" + escaped + "/@latest",
+		Headers: map[string]string{
+			"User-Agent": version.UserAgent(),
+		},
+	})
+	if err != nil {
+		return moduleInfo{}, err
+	}
+	if info.Version == "" {
+		return moduleInfo{}, fmt.Errorf("go list returned no latest version for %s", module)
+	}
+	return info, nil
+}
+
+type latestCache struct {
+	modules []string
+	once    sync.Once
+	mu      sync.Mutex
+	infos   map[string]moduleInfo
+	errs    map[string]error
+}
+
+func newLatestCache(modules []string) *latestCache {
+	return &latestCache{modules: modules}
+}
+
+func (c *latestCache) Get(ctx context.Context, module string) (moduleInfo, error) {
+	c.once.Do(func() {
+		c.fetch(ctx)
+	})
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.errs[module]; err != nil {
+		return moduleInfo{}, err
+	}
+	info, ok := c.infos[module]
+	if !ok {
+		var err error
+		info, err = latestModule(ctx, module)
+		if err != nil {
+			return moduleInfo{}, err
+		}
+		c.infos[module] = info
+	}
+	return info, nil
+}
+
+func (c *latestCache) fetch(ctx context.Context) {
+	c.mu.Lock()
+	c.infos = make(map[string]moduleInfo)
+	c.errs = make(map[string]error)
+	c.mu.Unlock()
+
+	g, ctx := errgroup.WithContext(ctx)
+	for _, module := range c.modules {
+		g.Go(func() error {
+			info, err := latestModule(ctx, module)
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if err != nil {
+				c.errs[module] = err
+				return nil
+			}
+			c.infos[module] = info
+			return nil
+		})
+	}
+
+	g.Wait()
+}
+
+func latestModules(packages []string) []string {
+	seen := make(map[string]bool)
+	var modules []string
+	for _, pkg := range packages {
+		_, version, ok := strings.Cut(pkg, "@")
+		if !ok || version != "latest" {
+			continue
+		}
+		module := packagePath(pkg)
+		if !seen[module] {
+			seen[module] = true
+			modules = append(modules, module)
+		}
+	}
+	return modules
+}
+
+func output(ctx context.Context, dir string, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/cmd/boot/internal/golang/golang_test.go
+++ b/cmd/boot/internal/golang/golang_test.go
@@ -1,0 +1,223 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package golang
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+
+	"go.starlark.net/starlark"
+)
+
+func TestGoInstallCreatesOneActionPerPackage(t *testing.T) {
+	root := t.TempDir()
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+	_, err := m.install(thread, starlark.NewBuiltin("go.install", m.install), starlark.Tuple{
+		starlark.NewList([]starlark.Value{
+			starlark.String("example.com/one@latest"),
+			starlark.String("example.com/two@latest"),
+		}),
+	}, nil)
+	if err != nil {
+		t.Fatalf("go.install failed: %v", err)
+	}
+	if len(task.Actions) != 2 {
+		t.Fatalf("got %d actions, want 2", len(task.Actions))
+	}
+	if got := task.Actions[0].Summary; !strings.Contains(got, "example.com/one@latest") {
+		t.Errorf("first action summary = %q", got)
+	}
+	if got := task.Actions[1].Summary; !strings.Contains(got, "example.com/two@latest") {
+		t.Errorf("second action summary = %q", got)
+	}
+}
+
+func TestGoInstallLocalConditions(t *testing.T) {
+	root := t.TempDir()
+	localDir := filepath.Join(root, "src")
+	if err := os.Mkdir(localDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+	_, err := m.installLocal(thread, starlark.NewBuiltin("go.install_local", m.installLocal), nil, []starlark.Tuple{
+		{starlark.String("package"), starlark.String("example.com/tool")},
+		{starlark.String("cwd"), starlark.String(localDir)},
+	})
+	if err != nil {
+		t.Fatalf("go.install_local failed: %v", err)
+	}
+	if len(task.Actions) != 2 {
+		t.Fatalf("got %d actions, want 2", len(task.Actions))
+	}
+
+	res, err := task.Actions[0].Apply(context.Background(), true)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+	res, err = task.Actions[1].Apply(context.Background(), true)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}
+
+func TestProxyUpToDateFixedVersion(t *testing.T) {
+	info := goBuildInfo{
+		Path:    "example.com/tool",
+		Module:  "example.com/tool",
+		Version: "v1.2.3",
+	}
+	upToDate, err := proxyUpToDate(context.Background(), "example.com/tool@v1.2.3", info, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !upToDate {
+		t.Fatal("fixed version should be up to date")
+	}
+}
+
+func TestLatestModuleUsesProxy(t *testing.T) {
+	oldProxy := goProxyURL
+	defer func() {
+		goProxyURL = oldProxy
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/example.com/hello/@latest" {
+			t.Errorf("request path = %q, want /example.com/hello/@latest", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"Version":"v1.2.3","Time":"2026-05-30T00:00:00Z"}`)
+	}))
+	defer server.Close()
+	goProxyURL = server.URL
+
+	info, err := latestModule(context.Background(), "example.com/hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Version != "v1.2.3" {
+		t.Fatalf("Version = %q, want v1.2.3", info.Version)
+	}
+}
+
+func TestLatestCacheFetchesConcurrently(t *testing.T) {
+	oldProxy := goProxyURL
+	defer func() {
+		goProxyURL = oldProxy
+	}()
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	var mu sync.Mutex
+	seen := make(map[string]bool)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := inFlight.Add(1)
+		defer inFlight.Add(-1)
+		for {
+			maximum := maxInFlight.Load()
+			if current <= maximum || maxInFlight.CompareAndSwap(maximum, current) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		seen[r.URL.Path] = true
+		mu.Unlock()
+		fmt.Fprint(w, `{"Version":"v1.2.3"}`)
+	}))
+	defer server.Close()
+	goProxyURL = server.URL
+
+	cache := newLatestCache([]string{"example.com/one", "example.com/two"})
+	if _, err := cache.Get(context.Background(), "example.com/one"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cache.Get(context.Background(), "example.com/two"); err != nil {
+		t.Fatal(err)
+	}
+	if maxInFlight.Load() < 2 {
+		t.Fatalf("proxy requests did not overlap; max in flight = %d", maxInFlight.Load())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, path := range []string{"/example.com/one/@latest", "/example.com/two/@latest"} {
+		if !seen[path] {
+			t.Fatalf("missing proxy request for %s; got %#v", path, seen)
+		}
+	}
+}
+
+func TestLocalUpToDate(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	root := t.TempDir()
+	testutil.RunGit(t, root, "init")
+	testutil.RunGit(t, root, "config", "user.email", "test@example.com")
+	testutil.RunGit(t, root, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/tool\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, root, "add", "go.mod")
+	testutil.RunGit(t, root, "commit", "-m", "initial")
+	head := strings.TrimSpace(testutil.RunGitOutput(t, root, "rev-parse", "HEAD"))
+
+	upToDate, err := localUpToDate(context.Background(), root, goBuildInfo{
+		Settings: map[string]string{
+			"vcs.revision": head,
+			"vcs.modified": "false",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !upToDate {
+		t.Fatal("clean checkout with matching revision should be up to date")
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	upToDate, err = localUpToDate(context.Background(), root, goBuildInfo{
+		Settings: map[string]string{
+			"vcs.revision": head,
+			"vcs.modified": "false",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upToDate {
+		t.Fatal("dirty checkout should not be up to date")
+	}
+}

--- a/cmd/boot/internal/module.go
+++ b/cmd/boot/internal/module.go
@@ -1,0 +1,104 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package internal
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+// Module contributes a Starlark module to a boot runtime.
+type Module interface {
+	// Name is the Starlark global name for this module.
+	Name() string
+	// Members returns the module members for the given runtime.
+	Members(*Runtime) starlark.StringDict
+}
+
+// Runtime is shared state used by Starlark modules.
+type Runtime struct {
+	Root        string
+	Home        string
+	Getenv      func(string) string
+	Stdin       io.Reader
+	Stdout      io.Writer
+	Interactive bool
+}
+
+const taskKey = "boot:task"
+
+// SetTask associates a task with a Starlark thread.
+func SetTask(thread *starlark.Thread, task *Task) {
+	thread.SetLocal(taskKey, task)
+}
+
+// AddAction appends an idempotent action to the task associated with the thread.
+func AddAction(thread *starlark.Thread, action Action) {
+	task := thread.Local(taskKey).(*Task)
+	task.Actions = append(task.Actions, action)
+}
+
+// InTask reports whether a Starlark builtin is currently running inside a task.
+func InTask(thread *starlark.Thread) bool {
+	return thread.Local(taskKey) != nil
+}
+
+// ResolveSource resolves a recipe source path.
+func (r *Runtime) ResolveSource(path string) string {
+	path = os.ExpandEnv(path)
+	path = strings.TrimPrefix(path, "//")
+	if strings.HasPrefix(path, "~/") {
+		return r.ExpandHome(path)
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(r.Root, filepath.FromSlash(path))
+}
+
+// ResolveTarget resolves a target path on the host.
+func (r *Runtime) ResolveTarget(path string) string {
+	path = os.ExpandEnv(path)
+	if strings.HasPrefix(path, "~/") {
+		return r.ExpandHome(path)
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(r.Root, filepath.FromSlash(path))
+}
+
+// ExpandHome expands a path beginning with ~/ against Runtime.Home.
+func (r *Runtime) ExpandHome(path string) string {
+	return filepath.Join(r.Home, filepath.FromSlash(strings.TrimPrefix(path, "~/")))
+}
+
+// NeedsSudo reports whether elevated privileges are required and available.
+func (r *Runtime) NeedsSudo() bool {
+	if os.Geteuid() == 0 {
+		return false
+	}
+	if r.Getenv("TERMUX_VERSION") != "" || strings.Contains(r.Getenv("PREFIX"), "termux") {
+		return false
+	}
+	return true
+}
+
+// Hostname returns the configured host name, honoring Termux's prefs hostname file.
+func (r *Runtime) Hostname() (string, error) {
+	if r != nil && r.Home != "" {
+		path := r.ExpandHome("~/local/data/termux/hostname")
+		if data, err := os.ReadFile(path); err == nil {
+			if name := strings.TrimSpace(string(data)); name != "" {
+				return name, nil
+			}
+		}
+	}
+	return os.Hostname()
+}

--- a/cmd/boot/internal/module_test.go
+++ b/cmd/boot/internal/module_test.go
@@ -1,0 +1,49 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package internal
+
+import (
+	"testing"
+)
+
+func TestNeedsSudo(t *testing.T) {
+	cases := map[string]struct {
+		env  map[string]string
+		want bool
+	}{
+		"standard user": {
+			env:  nil,
+			want: true,
+		},
+		"termux by version": {
+			env:  map[string]string{"TERMUX_VERSION": "0.118.0"},
+			want: false,
+		},
+		"termux by prefix": {
+			env:  map[string]string{"PREFIX": "/data/data/com.termux/files/usr"},
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rt := &Runtime{
+				Getenv: func(key string) string {
+					if tc.env == nil {
+						return ""
+					}
+					return tc.env[key]
+				},
+			}
+			// Note: We can't easily mock os.Geteuid() without refactoring,
+			// but we can test the Termux detection logic assuming Geteuid != 0.
+			// Since this test likely runs as non-root in CI, it's fine.
+			got := rt.NeedsSudo()
+			if got != tc.want {
+				t.Errorf("NeedsSudo() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/boot/internal/packages/doc.go
+++ b/cmd/boot/internal/packages/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package packages provides boot Starlark primitives for package managers.
+package packages

--- a/cmd/boot/internal/packages/packages.go
+++ b/cmd/boot/internal/packages/packages.go
@@ -1,0 +1,346 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package packages
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"sync"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark pkg module.
+func Module() boot.Module { return &module{} }
+
+type module struct {
+	mu      sync.Mutex
+	manager string
+	pkgMu   sync.Mutex
+}
+
+func (*module) Name() string { return "pkg" }
+
+func (m *module) Members(rt *boot.Runtime) starlark.StringDict {
+	impl := &impl{rt: rt, mod: m}
+	return starlark.StringDict{
+		"check_explicit_packages": starlark.NewBuiltin("pkg.check_explicit_packages", impl.checkExplicitPackages),
+		"configure":               starlark.NewBuiltin("pkg.configure", impl.configure),
+		"install":                 starlark.NewBuiltin("pkg.install", impl.install),
+		"manager":                 starlark.NewBuiltin("pkg.manager", impl.manager),
+		"update":                  starlark.NewBuiltin("pkg.update", impl.update),
+	}
+}
+
+type impl struct {
+	rt  *boot.Runtime
+	mod *module
+}
+
+func (m *impl) configure(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var manager string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "manager", &manager); err != nil {
+		return nil, err
+	}
+	if _, err := packageManagerByName(m.rt, manager); err != nil {
+		return nil, err
+	}
+	m.mod.mu.Lock()
+	m.mod.manager = manager
+	m.mod.mu.Unlock()
+	return starlark.None, nil
+}
+
+func (m *impl) manager(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if len(args) > 0 || len(kwargs) > 0 {
+		return nil, fmt.Errorf("%s: unexpected arguments", b.Name())
+	}
+	pm, err := m.resolveManager()
+	if err != nil {
+		return nil, err
+	}
+	return starlark.String(pm.name), nil
+}
+
+func (m *impl) install(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var packages *starlark.List
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "packages", &packages); err != nil {
+		return nil, err
+	}
+	names, err := boot.StringList("packages", packages)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", b.Name(), err)
+	}
+	if len(names) == 0 {
+		return starlark.None, nil
+	}
+	slices.Sort(names)
+	names = slices.Compact(names)
+
+	pm, err := m.resolveManager()
+	if err != nil {
+		return nil, err
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("install packages with %s: %s", pm.name, strings.Join(names, ", ")),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			m.mod.pkgMu.Lock()
+			defer m.mod.pkgMu.Unlock()
+
+			missing, err := pm.missing(ctx, names)
+			if err != nil {
+				return "", err
+			}
+			if len(missing) == 0 {
+				return boot.ResultSkip, nil
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			return boot.ResultChange, pm.install(ctx, missing)
+		},
+	})
+	return starlark.None, nil
+}
+
+func (m *impl) update(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs); err != nil {
+		return nil, err
+	}
+
+	pm, err := m.resolveManager()
+	if err != nil {
+		return nil, err
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("update system with %s", pm.name),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			m.mod.pkgMu.Lock()
+			defer m.mod.pkgMu.Unlock()
+
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			return boot.ResultChange, pm.update(ctx)
+		},
+	})
+	return starlark.None, nil
+}
+
+func (m *impl) checkExplicitPackages(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+	var packages *starlark.List
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "packages", &packages); err != nil {
+		return nil, err
+	}
+	defined, err := boot.StringList("packages", packages)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", b.Name(), err)
+	}
+	slices.Sort(defined)
+	defined = slices.Compact(defined)
+	pm, err := m.resolveManager()
+	if err != nil {
+		return nil, err
+	}
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("check explicit packages with %s", pm.name),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			installed, err := pm.explicit(ctx)
+			if err != nil {
+				return "", err
+			}
+			known := make(map[string]bool)
+			for _, pkg := range defined {
+				known[pkg] = true
+			}
+			var extra []string
+			for _, pkg := range installed {
+				if !known[pkg] {
+					extra = append(extra, pkg)
+				}
+			}
+			if len(extra) == 0 {
+				return boot.ResultSkip, nil
+			}
+			slices.Sort(extra)
+			fmt.Fprintf(output(m.rt), "explicit packages missing from recipe:\n%s\n", bulletList(extra))
+			return boot.ResultWarn, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func output(rt *boot.Runtime) io.Writer {
+	if rt != nil && rt.Stdout != nil {
+		return rt.Stdout
+	}
+	return os.Stdout
+}
+
+func bulletList(items []string) string {
+	var buf strings.Builder
+	for _, item := range items {
+		fmt.Fprintf(&buf, "  - %s\n", item)
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+func (m *impl) resolveManager() (packageManager, error) {
+	m.mod.mu.Lock()
+	defer m.mod.mu.Unlock()
+
+	if m.mod.manager != "" {
+		return packageManagerByName(m.rt, m.mod.manager)
+	}
+
+	manager := m.rt.Getenv("BOOT_PACKAGE_MANAGER")
+	if manager == "" {
+		if _, err := exec.LookPath("pacman"); err == nil {
+			manager = "pacman"
+		} else if _, err := exec.LookPath("apt"); err == nil {
+			manager = "apt"
+		} else if _, err := exec.LookPath("pkg"); err == nil {
+			manager = "apt"
+		}
+	}
+
+	if manager != "" {
+		m.mod.manager = manager
+		return packageManagerByName(m.rt, manager)
+	}
+
+	return packageManager{}, errors.New("no supported package manager found")
+}
+
+type packageManager struct {
+	name        string
+	missing     func(context.Context, []string) ([]string, error)
+	explicit    func(context.Context) ([]string, error)
+	installArgv func([]string) []string
+	update      func(context.Context) error
+}
+
+func (pm packageManager) install(ctx context.Context, packages []string) error {
+	argv := pm.installArgv(packages)
+	return boot.RunCommand(ctx, "", argv...)
+}
+
+func sudoArgs(rt *boot.Runtime, args ...string) []string {
+	if rt.NeedsSudo() {
+		return append([]string{"sudo"}, args...)
+	}
+	return args
+}
+
+func packageManagerByName(rt *boot.Runtime, name string) (packageManager, error) {
+	switch name {
+	case "apt":
+		return packageManager{
+			name: "apt",
+			missing: func(ctx context.Context, packages []string) ([]string, error) {
+				// dpkg-query -W -f='${Package} ${Status}\n' pkg1 pkg2 ...
+				args := append([]string{"-W", "-f=${Package} ${Status}\n"}, packages...)
+				cmd := exec.CommandContext(ctx, "dpkg-query", args...)
+				out, _ := cmd.CombinedOutput() // ignore error, as it returns 1 if any package is missing.
+
+				found := make(map[string]bool)
+				lines := strings.SplitSeq(string(out), "\n")
+				for line := range lines {
+					if strings.Contains(line, "install ok installed") {
+						fields := strings.Fields(line)
+						if len(fields) > 0 {
+							found[fields[0]] = true
+						}
+					}
+				}
+
+				var missing []string
+				for _, pkg := range packages {
+					if !found[pkg] {
+						missing = append(missing, pkg)
+					}
+				}
+				return missing, nil
+			},
+			explicit: func(ctx context.Context) ([]string, error) {
+				cmd := exec.CommandContext(ctx, "apt-mark", "showmanual")
+				out, err := cmd.Output()
+				if err != nil {
+					return nil, err
+				}
+				return strings.Fields(string(out)), nil
+			},
+			installArgv: func(packages []string) []string {
+				return sudoArgs(rt, append([]string{"apt", "install", "-y"}, packages...)...)
+			},
+			update: func(ctx context.Context) error {
+				var cmdLine string
+				if rt.NeedsSudo() {
+					cmdLine = "sudo apt update && sudo apt upgrade -y"
+				} else {
+					cmdLine = "apt update && apt upgrade -y"
+				}
+				return boot.RunCommand(ctx, "", "sh", "-c", cmdLine)
+			},
+		}, nil
+	case "pacman":
+		return packageManager{
+			name: "pacman",
+			missing: func(ctx context.Context, packages []string) ([]string, error) {
+				// pacman -T lists missing packages.
+				args := append([]string{"-T"}, packages...)
+				cmd := exec.CommandContext(ctx, "pacman", args...)
+				out, err := cmd.Output()
+				if err != nil {
+					// pacman -T exits non-zero when dependencies are missing and
+					// prints the missing dependency names on stdout.
+					var exitErr *exec.ExitError
+					if errors.As(err, &exitErr) && len(strings.TrimSpace(string(out))) > 0 {
+						return strings.Fields(string(out)), nil
+					}
+					return nil, err
+				}
+				return nil, nil
+			},
+			explicit: func(ctx context.Context) ([]string, error) {
+				cmd := exec.CommandContext(ctx, "pacman", "-Qqen")
+				out, err := cmd.Output()
+				if err != nil {
+					return nil, err
+				}
+				return strings.Fields(string(out)), nil
+			},
+			installArgv: func(packages []string) []string {
+				return sudoArgs(rt, append([]string{"pacman", "-S", "--noconfirm", "--needed"}, packages...)...)
+			},
+			update: func(ctx context.Context) error {
+				args := sudoArgs(rt, "pacman", "-Syu", "--noconfirm")
+				return boot.RunCommand(ctx, "", args...)
+			},
+		}, nil
+	default:
+		return packageManager{}, fmt.Errorf("unsupported package manager %q", name)
+	}
+}

--- a/cmd/boot/internal/packages/packages_test.go
+++ b/cmd/boot/internal/packages/packages_test.go
@@ -1,0 +1,113 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package packages
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+)
+
+func TestPackageManagerAptMissing(t *testing.T) {
+	bin := t.TempDir()
+	testutil.WriteCommand(t, bin, "dpkg-query", `#!/bin/sh
+for arg in "$@"; do
+    case "$arg" in
+    installed) echo "installed install ok installed" ;;
+    missing) ;;
+    esac
+done
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	rt := &boot.Runtime{Getenv: os.Getenv}
+	pm, err := packageManagerByName(rt, "apt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing, err := pm.missing(context.Background(), []string{"installed", "missing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing) != 1 || missing[0] != "missing" {
+		t.Fatalf("missing = %v, want [missing]", missing)
+	}
+}
+
+func TestPackageManagerPacmanMissing(t *testing.T) {
+	bin := t.TempDir()
+	testutil.WriteCommand(t, bin, "pacman", `#!/bin/sh
+for arg in "$@"; do
+    case "$arg" in
+    missing) echo "missing"; exit 127 ;;
+    esac
+done
+exit 0
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	rt := &boot.Runtime{Getenv: os.Getenv}
+	pm, err := packageManagerByName(rt, "pacman")
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing, err := pm.missing(context.Background(), []string{"installed", "missing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing) != 1 || missing[0] != "missing" {
+		t.Fatalf("missing = %v, want [missing]", missing)
+	}
+}
+
+func TestPackageManagerAptUpdate(t *testing.T) {
+	bin := t.TempDir()
+	testutil.WriteCommand(t, bin, "sh", `#!/bin/sh
+case "$2" in
+"apt update && apt upgrade -y") exit 0 ;;
+"sudo apt update && sudo apt upgrade -y") exit 0 ;;
+*) exit 1 ;;
+esac
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	rt := &boot.Runtime{Getenv: os.Getenv}
+	pm, err := packageManagerByName(rt, "apt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.update(context.Background()); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+}
+
+func TestPackageManagerPacmanUpdate(t *testing.T) {
+	bin := t.TempDir()
+	testutil.WriteCommand(t, bin, "sudo", `#!/bin/sh
+if [ "$1" = "pacman" ] && [ "$2" = "-Syu" ] && [ "$3" = "--noconfirm" ]; then
+	exit 0
+fi
+exit 1
+`)
+	testutil.WriteCommand(t, bin, "pacman", `#!/bin/sh
+if [ "$1" = "-Syu" ] && [ "$2" = "--noconfirm" ]; then
+	exit 0
+fi
+exit 1
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	rt := &boot.Runtime{Getenv: os.Getenv}
+	pm, err := packageManagerByName(rt, "pacman")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.update(context.Background()); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+}

--- a/cmd/boot/internal/pacman/pacman.go
+++ b/cmd/boot/internal/pacman/pacman.go
@@ -1,0 +1,236 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package pacman
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark pacman module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "pacman" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"check_explicit_packages": starlark.NewBuiltin("pacman.check_explicit_packages", m.checkExplicitPackages),
+		"check_orphans":           starlark.NewBuiltin("pacman.check_orphans", m.checkOrphans),
+		"check_pacnew":            starlark.NewBuiltin("pacman.check_pacnew", m.checkPacnew),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) checkOrphans(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs); err != nil {
+		return nil, err
+	}
+	boot.AddAction(thread, boot.Action{
+		Summary: "check pacman orphaned packages",
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			cmd := exec.CommandContext(ctx, "pacman", "-Qtdq")
+			out, err := cmd.Output()
+			if err != nil {
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+					return boot.ResultSkip, nil
+				}
+				return "", err
+			}
+			orphans := strings.Fields(string(out))
+			if len(orphans) == 0 {
+				return boot.ResultSkip, nil
+			}
+			fmt.Fprintf(output(m.rt), "orphaned packages found:\n%s\n", bulletList(orphans))
+			fmt.Fprintln(output(m.rt), "remove them with: sudo pacman -Rns $(pacman -Qtdq)")
+			return boot.ResultWarn, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func (m *impl) checkExplicitPackages(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+	var packages *starlark.List
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "packages", &packages); err != nil {
+		return nil, err
+	}
+	defined, err := boot.StringList("packages", packages)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", b.Name(), err)
+	}
+	slices.Sort(defined)
+	defined = slices.Compact(defined)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: "check pacman explicit package list",
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			cmd := exec.CommandContext(ctx, "pacman", "-Qqen")
+			out, err := cmd.Output()
+			if err != nil {
+				return "", err
+			}
+			known := make(map[string]bool)
+			for _, pkg := range defined {
+				known[pkg] = true
+			}
+			var extra []string
+			for pkg := range strings.FieldsSeq(string(out)) {
+				if !known[pkg] {
+					extra = append(extra, pkg)
+				}
+			}
+			if len(extra) == 0 {
+				return boot.ResultSkip, nil
+			}
+			slices.Sort(extra)
+			fmt.Fprintf(output(m.rt), "explicit packages missing from recipe:\n%s\n", bulletList(extra))
+			return boot.ResultWarn, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func (m *impl) checkPacnew(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+	var prefsEtc string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "prefs_etc", &prefsEtc); err != nil {
+		return nil, err
+	}
+	prefsEtc = m.rt.ResolveSource(prefsEtc)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: "check pacman .pacnew files",
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			files, err := pacnewFiles("/etc")
+			if err != nil {
+				return "", err
+			}
+			if len(files) == 0 {
+				return boot.ResultSkip, nil
+			}
+			var managed, unmanaged []string
+			for _, path := range files {
+				original := strings.TrimSuffix(path, ".pacnew")
+				rel, err := filepath.Rel("/etc", original)
+				if err != nil {
+					unmanaged = append(unmanaged, path)
+					continue
+				}
+				if _, err := os.Stat(filepath.Join(prefsEtc, rel)); err == nil {
+					managed = append(managed, path)
+				} else {
+					unmanaged = append(unmanaged, path)
+				}
+			}
+
+			var buf bytes.Buffer
+			fmt.Fprintln(&buf, ".pacnew files found")
+			if len(managed) > 0 {
+				fmt.Fprintln(&buf, "managed by prefs:")
+				fmt.Fprintln(&buf, bulletList(managed))
+				fmt.Fprintln(&buf, pacnewDiffs(ctx, managed))
+			}
+			if len(unmanaged) > 0 {
+				fmt.Fprintln(&buf, "unmanaged:")
+				fmt.Fprintln(&buf, bulletList(unmanaged))
+				fmt.Fprintln(&buf, pacnewDiffs(ctx, unmanaged))
+			}
+			fmt.Fprintln(output(m.rt), strings.TrimSpace(buf.String()))
+			return boot.ResultWarn, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func pacnewFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.Type().IsRegular() && strings.HasSuffix(path, ".pacnew") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	slices.Sort(files)
+	return files, err
+}
+
+func bulletList(items []string) string {
+	var buf strings.Builder
+	for _, item := range items {
+		fmt.Fprintf(&buf, "  - %s\n", item)
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+func output(rt *boot.Runtime) io.Writer {
+	if rt != nil && rt.Stdout != nil {
+		return rt.Stdout
+	}
+	return os.Stdout
+}
+
+func pacnewDiffs(ctx context.Context, files []string) string {
+	const maxLines = 30
+	var buf strings.Builder
+	for _, path := range files {
+		original := strings.TrimSuffix(path, ".pacnew")
+		fmt.Fprintf(&buf, "diff for %s:\n", path)
+		if _, err := os.Stat(original); errors.Is(err, fs.ErrNotExist) {
+			fmt.Fprintln(&buf, "  (current file does not exist)")
+			continue
+		}
+		cmd := exec.CommandContext(ctx, "diff", "-u", original, path)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+				fmt.Fprintf(&buf, "  (could not diff files: %v)\n", err)
+				continue
+			}
+		}
+		lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+		if len(lines) == 1 && lines[0] == "" {
+			fmt.Fprintln(&buf, "  (no differences found)")
+			continue
+		}
+		if len(lines) > maxLines {
+			lines = lines[:maxLines]
+		}
+		for _, line := range lines {
+			fmt.Fprintf(&buf, "  %s\n", line)
+		}
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}

--- a/cmd/boot/internal/rescue/rescue.go
+++ b/cmd/boot/internal/rescue/rescue.go
@@ -1,0 +1,244 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package rescue
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark rescue module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "rescue" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"update": starlark.NewBuiltin("rescue.update", m.update),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) update(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+	var (
+		source string
+		espDir string = "/efi/EFI/Linux"
+		keep   int    = 3
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"source", &source,
+		"esp_dir?", &espDir,
+		"keep?", &keep,
+	); err != nil {
+		return nil, err
+	}
+	src := m.rt.ResolveSource(source)
+	esp := m.rt.ResolveTarget(espDir)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("update rescue image from %s", src),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if _, err := os.Stat(src); err != nil {
+				return "", err
+			}
+			if _, err := os.Stat(esp); err != nil {
+				return boot.ResultSkip, nil
+			}
+			images, err := rescueImages(esp)
+			if err != nil {
+				return "", err
+			}
+			if len(images) > 0 && sameMonth(images[0].modTime, time.Now()) {
+				return boot.ResultSkip, nil
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if err := run(ctx, false, src, "mkosi", "build"); err != nil {
+				return "", err
+			}
+			built, err := latestBuiltImage(filepath.Join(src, "mkosi.output"))
+			if err != nil {
+				return "", err
+			}
+			target := filepath.Join(esp, filepath.Base(built))
+			if err := run(ctx, m.rt.NeedsSudo(), "", "cp", built, target); err != nil {
+				return "", err
+			}
+			if err := run(ctx, m.rt.NeedsSudo(), "", "sbctl", "sign", "-s", target); err != nil {
+				_ = run(ctx, m.rt.NeedsSudo(), "", "rm", "-f", target)
+				return "", err
+			}
+			if err := prune(ctx, m.rt, esp, keep); err != nil {
+				return "", err
+			}
+			if err := pruneOutput(ctx, m.rt, filepath.Join(src, "mkosi.output"), keep); err != nil {
+				return "", err
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+type image struct {
+	path    string
+	modTime time.Time
+}
+
+func rescueImages(dir string) ([]image, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var images []image
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "arch-linux-rescue_") || !strings.HasSuffix(entry.Name(), ".efi") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, image{path: filepath.Join(dir, entry.Name()), modTime: info.ModTime()})
+	}
+	slices.SortFunc(images, func(a, b image) int { return b.modTime.Compare(a.modTime) })
+	return images, nil
+}
+
+func latestBuiltImage(dir string) (string, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "arch-linux-rescue_*.efi"))
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no built rescue image found in %s", dir)
+	}
+	slices.SortFunc(matches, func(a, b string) int {
+		ai, aerr := os.Stat(a)
+		bi, berr := os.Stat(b)
+		if aerr != nil || berr != nil {
+			return strings.Compare(b, a)
+		}
+		return bi.ModTime().Compare(ai.ModTime())
+	})
+	return matches[0], nil
+}
+
+func sameMonth(a, b time.Time) bool {
+	return a.Year() == b.Year() && a.Month() == b.Month()
+}
+
+func prune(ctx context.Context, rt *boot.Runtime, esp string, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	images, err := rescueImages(esp)
+	if err != nil {
+		return err
+	}
+	for _, image := range images[keep:] {
+		if err := run(ctx, rt.NeedsSudo(), "", "rm", "-f", image.path); err != nil {
+			return err
+		}
+		_ = run(ctx, rt.NeedsSudo(), "", "sbctl", "remove-file", image.path)
+	}
+	return nil
+}
+
+var rescueOutputPattern = regexp.MustCompile(`arch-linux-rescue_(\d{12})`)
+
+type outputBuild struct {
+	stamp string
+	paths []string
+}
+
+func rescueOutputBuilds(dir string) ([]outputBuild, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	builds := make(map[string][]string)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		match := rescueOutputPattern.FindStringSubmatch(entry.Name())
+		if match == nil {
+			continue
+		}
+		stamp := match[1]
+		builds[stamp] = append(builds[stamp], filepath.Join(dir, entry.Name()))
+	}
+	out := make([]outputBuild, 0, len(builds))
+	for stamp, paths := range builds {
+		slices.Sort(paths)
+		out = append(out, outputBuild{stamp: stamp, paths: paths})
+	}
+	slices.SortFunc(out, func(a, b outputBuild) int { return strings.Compare(b.stamp, a.stamp) })
+	return out, nil
+}
+
+func pruneOutput(ctx context.Context, rt *boot.Runtime, dir string, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	builds, err := rescueOutputBuilds(dir)
+	if err != nil {
+		return err
+	}
+	for _, build := range builds[keep:] {
+		for _, path := range build.paths {
+			if err := run(ctx, rt.NeedsSudo(), "", "rm", "-f", path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func run(ctx context.Context, sudo bool, dir, name string, args ...string) error {
+	argv := append([]string{name}, args...)
+	if sudo {
+		argv = append([]string{"sudo"}, argv...)
+	}
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	msg := strings.TrimSpace(string(out))
+	if msg == "" {
+		return fmt.Errorf("%s failed: %w", strings.Join(argv, " "), err)
+	}
+	return fmt.Errorf("%s failed: %w:\n%s", strings.Join(argv, " "), err, msg)
+}

--- a/cmd/boot/internal/rescue/rescue_test.go
+++ b/cmd/boot/internal/rescue/rescue_test.go
@@ -1,0 +1,86 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package rescue
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+)
+
+func TestRescueOutputBuildsGroupsTimestampedFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "arch-linux-rescue_202605010102.efi"))
+	writeFile(t, filepath.Join(dir, "arch-linux-rescue_202605010102.efi.sig"))
+	writeFile(t, filepath.Join(dir, "arch-linux-rescue_202604010102.efi"))
+	writeFile(t, filepath.Join(dir, "unrelated.txt"))
+
+	builds, err := rescueOutputBuilds(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(builds) != 2 {
+		t.Fatalf("got %d builds, want 2", len(builds))
+	}
+	if builds[0].stamp != "202605010102" {
+		t.Fatalf("first stamp = %s, want 202605010102", builds[0].stamp)
+	}
+	if len(builds[0].paths) != 2 {
+		t.Fatalf("first build has %d paths, want 2", len(builds[0].paths))
+	}
+}
+
+func TestPruneOutputKeepsNewestBuilds(t *testing.T) {
+	root := t.TempDir()
+	bin := t.TempDir()
+	testutil.WriteCommand(t, bin, "rm", `#!/bin/sh
+for arg in "$@"; do
+	if [ "$arg" != "-f" ]; then
+		/bin/rm -f "$arg"
+	fi
+done
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	files := []string{
+		"arch-linux-rescue_202605010102.efi",
+		"arch-linux-rescue_202605010102.efi.sig",
+		"arch-linux-rescue_202604010102.efi",
+		"arch-linux-rescue_202603010102.efi",
+		"unrelated.txt",
+	}
+	for _, name := range files {
+		writeFile(t, filepath.Join(root, name))
+	}
+
+	if err := pruneOutput(context.Background(), &boot.Runtime{Getenv: func(string) string { return "termux" }}, root, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{
+		"arch-linux-rescue_202605010102.efi",
+		"arch-linux-rescue_202605010102.efi.sig",
+		"arch-linux-rescue_202604010102.efi",
+		"unrelated.txt",
+	} {
+		if _, err := os.Stat(filepath.Join(root, name)); err != nil {
+			t.Fatalf("%s was removed: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "arch-linux-rescue_202603010102.efi")); !os.IsNotExist(err) {
+		t.Fatalf("old build still exists: %v", err)
+	}
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/boot/internal/shell/shell.go
+++ b/cmd/boot/internal/shell/shell.go
@@ -1,0 +1,163 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package shell
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark shell module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "shell" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"run":    starlark.NewBuiltin("shell.run", m.run),
+		"output": starlark.NewBuiltin("shell.output", m.output),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) run(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		command string
+		creates string
+		onlyIf  string
+		cwd     string
+		sudo    bool
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"command", &command,
+		"creates?", &creates,
+		"only_if?", &onlyIf,
+		"cwd?", &cwd,
+		"sudo?", &sudo,
+	); err != nil {
+		return nil, err
+	}
+
+	summary := "run: " + command
+	if creates != "" {
+		summary += " (creates " + creates + ")"
+	}
+	if onlyIf != "" {
+		summary += " (only_if " + onlyIf + ")"
+	}
+	if cwd != "" {
+		summary += " (cwd " + cwd + ")"
+	}
+	if sudo {
+		summary += " (sudo)"
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: summary,
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if creates != "" {
+				abs := m.rt.ResolveTarget(creates)
+				if _, err := os.Stat(abs); err == nil {
+					return boot.ResultSkip, nil
+				}
+			}
+
+			if onlyIf != "" {
+				var cmd *exec.Cmd
+				if sudo && m.rt.NeedsSudo() {
+					cmd = exec.CommandContext(ctx, "sudo", "sh", "-c", onlyIf)
+				} else {
+					cmd = exec.CommandContext(ctx, "sh", "-c", onlyIf)
+				}
+				if cwd != "" {
+					cmd.Dir = m.rt.ResolveTarget(cwd)
+				}
+				if err := cmd.Run(); err != nil {
+					return boot.ResultSkip, nil
+				}
+			}
+
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+
+			var cmd *exec.Cmd
+			if sudo && m.rt.NeedsSudo() {
+				cmd = exec.CommandContext(ctx, "sudo", "sh", "-c", command)
+			} else {
+				cmd = exec.CommandContext(ctx, "sh", "-c", command)
+			}
+			if cwd != "" {
+				cmd.Dir = m.rt.ResolveTarget(cwd)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				msg := strings.TrimSpace(string(out))
+				if msg == "" {
+					return "", err
+				}
+				return "", fmt.Errorf("%w:\n%s", err, msg)
+			}
+
+			return boot.ResultChange, nil
+		},
+	})
+
+	return starlark.None, nil
+}
+
+func (m *impl) output(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		command string
+		cwd     string
+		sudo    bool
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"command", &command,
+		"cwd?", &cwd,
+		"sudo?", &sudo,
+	); err != nil {
+		return nil, err
+	}
+
+	var cmd *exec.Cmd
+	if sudo && m.rt.NeedsSudo() {
+		cmd = exec.Command("sudo", "sh", "-c", command)
+	} else {
+		cmd = exec.Command("sh", "-c", command)
+	}
+	if cwd != "" {
+		cmd.Dir = m.rt.ResolveTarget(cwd)
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return nil, fmt.Errorf("%s failed: %w", command, err)
+		}
+		return nil, fmt.Errorf("%s failed: %w:\n%s", command, err, msg)
+	}
+	return starlark.String(out), nil
+}

--- a/cmd/boot/internal/shell/shell_test.go
+++ b/cmd/boot/internal/shell/shell_test.go
@@ -1,0 +1,131 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package shell
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+	"go.starlark.net/starlark"
+)
+
+func TestShellRun(t *testing.T) {
+	cases := map[string]struct {
+		setup   func(t *testing.T, root string)
+		command string
+		creates string
+		onlyIf  string
+		dryRun  bool
+		want    boot.Result
+		check   func(t *testing.T, root string)
+	}{
+		"basic run": {
+			command: "echo test > {{ROOT}}/test.txt",
+			want:    boot.ResultChange,
+			check: func(t *testing.T, root string) {
+				got, err := os.ReadFile(filepath.Join(root, "test.txt"))
+				if err != nil || string(got) != "test\n" {
+					t.Errorf("file content = %q, %v; want \"test\\n\", nil", got, err)
+				}
+			},
+		},
+		"creates file exists": {
+			setup: func(t *testing.T, root string) {
+				os.WriteFile(filepath.Join(root, "exists.txt"), []byte("ok"), 0o644)
+			},
+			command: "echo test > {{ROOT}}/should_not_exist.txt",
+			creates: "exists.txt",
+			want:    boot.ResultSkip,
+			check: func(t *testing.T, root string) {
+				if _, err := os.Stat(filepath.Join(root, "should_not_exist.txt")); !errors.Is(err, fs.ErrNotExist) {
+					t.Errorf("file should not exist")
+				}
+			},
+		},
+		"only_if fails": {
+			command: "echo test > {{ROOT}}/should_not_exist.txt",
+			onlyIf:  "false",
+			want:    boot.ResultSkip,
+			check: func(t *testing.T, root string) {
+				if _, err := os.Stat(filepath.Join(root, "should_not_exist.txt")); !errors.Is(err, fs.ErrNotExist) {
+					t.Errorf("file should not exist")
+				}
+			},
+		},
+		"only_if succeeds": {
+			command: "echo test > {{ROOT}}/test.txt",
+			onlyIf:  "true",
+			want:    boot.ResultChange,
+			check: func(t *testing.T, root string) {
+				if _, err := os.Stat(filepath.Join(root, "test.txt")); err != nil {
+					t.Errorf("file should exist")
+				}
+			},
+		},
+		"dry run": {
+			command: "echo test > {{ROOT}}/should_not_exist.txt",
+			dryRun:  true,
+			want:    boot.ResultChange,
+			check: func(t *testing.T, root string) {
+				if _, err := os.Stat(filepath.Join(root, "should_not_exist.txt")); !errors.Is(err, fs.ErrNotExist) {
+					t.Errorf("file should not exist in dry run")
+				}
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			if tc.setup != nil {
+				tc.setup(t, root)
+			}
+
+			rt := &boot.Runtime{Root: root}
+			task, thread := testutil.TaskThread("test")
+
+			m := &impl{rt: rt}
+
+			// Replace {{ROOT}} template
+			cmd := starlark.String(strings.ReplaceAll(tc.command, "{{ROOT}}", root))
+
+			kwargs := []starlark.Tuple{}
+			if tc.creates != "" {
+				kwargs = append(kwargs, starlark.Tuple{starlark.String("creates"), starlark.String(tc.creates)})
+			}
+			if tc.onlyIf != "" {
+				kwargs = append(kwargs, starlark.Tuple{starlark.String("only_if"), starlark.String(tc.onlyIf)})
+			}
+
+			_, err := m.run(thread, starlark.NewBuiltin("shell.run", m.run), starlark.Tuple{cmd}, kwargs)
+			if err != nil {
+				t.Fatalf("run failed: %v", err)
+			}
+
+			if len(task.Actions) != 1 {
+				t.Fatalf("got %d actions, want 1", len(task.Actions))
+			}
+
+			res, err := task.Actions[0].Apply(context.Background(), tc.dryRun)
+			if err != nil {
+				t.Fatalf("apply failed: %v", err)
+			}
+			if res != tc.want {
+				t.Errorf("got result %v, want %v", res, tc.want)
+			}
+
+			if tc.check != nil {
+				tc.check(t, root)
+			}
+		})
+	}
+}

--- a/cmd/boot/internal/ssh/doc.go
+++ b/cmd/boot/internal/ssh/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package ssh provides boot Starlark primitives for SSH configuration.
+package ssh

--- a/cmd/boot/internal/ssh/ssh.go
+++ b/cmd/boot/internal/ssh/ssh.go
@@ -1,0 +1,96 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark ssh module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "ssh" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"key": starlark.NewBuiltin("ssh.key", m.key),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) key(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+
+	var (
+		path       string
+		keyType    string = "ed25519"
+		comment    string
+		passphrase string
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"path", &path,
+		"type?", &keyType,
+		"comment?", &comment,
+		"passphrase?", &passphrase,
+	); err != nil {
+		return nil, err
+	}
+	if comment == "" {
+		hostname, err := m.rt.Hostname()
+		if err != nil {
+			return nil, err
+		}
+		comment = hostname
+	}
+	abs := m.rt.ResolveTarget(path)
+
+	boot.AddAction(thread, boot.Action{
+		Summary: fmt.Sprintf("ssh-keygen %s %s", keyType, abs),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			if _, err := os.Stat(abs); err == nil {
+				return boot.ResultSkip, nil
+			} else if !errors.Is(err, fs.ErrNotExist) {
+				return "", err
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if err := os.MkdirAll(filepath.Dir(abs), 0o700); err != nil {
+				return "", err
+			}
+			cmd := exec.CommandContext(ctx, "ssh-keygen", "-q", "-t", keyType, "-C", comment, "-N", passphrase, "-f", abs)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				msg := strings.TrimSpace(string(out))
+				if msg == "" {
+					return "", err
+				}
+				return "", fmt.Errorf("%w:\n%s", err, msg)
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}

--- a/cmd/boot/internal/ssh/ssh_test.go
+++ b/cmd/boot/internal/ssh/ssh_test.go
@@ -1,0 +1,46 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package ssh
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+
+	"go.starlark.net/starlark"
+)
+
+func TestSSHKeySkipsExistingKey(t *testing.T) {
+	root := t.TempDir()
+	keyPath := filepath.Join(root, "key")
+	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+
+	m := &impl{rt: rt}
+	_, err := m.key(thread, starlark.NewBuiltin("ssh.key", m.key), nil, []starlark.Tuple{
+		{starlark.String("path"), starlark.String(keyPath)},
+	})
+	if err != nil {
+		t.Fatalf("ssh.key failed: %v", err)
+	}
+	if len(task.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(task.Actions))
+	}
+	res, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}

--- a/cmd/boot/internal/starlark.go
+++ b/cmd/boot/internal/starlark.go
@@ -1,0 +1,31 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package internal
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+// Common Starlark utilities.
+
+// StringList converts [starlark.List] to []string.
+func StringList(name string, list *starlark.List) ([]string, error) {
+	if list == nil {
+		return nil, fmt.Errorf("%s list is required", name)
+	}
+	names := make([]string, 0, list.Len())
+	for i := range list.Len() {
+		name, ok := starlark.AsString(list.Index(i))
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] is not a string", name, i)
+		}
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}

--- a/cmd/boot/internal/systemd/systemd.go
+++ b/cmd/boot/internal/systemd/systemd.go
@@ -1,0 +1,194 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package systemd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// Module returns the Starlark systemd module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "systemd" }
+
+func (module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt}
+	return starlark.StringDict{
+		"system_unit": starlark.NewBuiltin("systemd.system_unit", m.systemUnit),
+		"user_unit":   starlark.NewBuiltin("systemd.user_unit", m.userUnit),
+	}
+}
+
+type impl struct {
+	rt *boot.Runtime
+}
+
+func (m *impl) userUnit(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return m.unit(thread, b, true, args, kwargs)
+}
+
+func (m *impl) systemUnit(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return m.unit(thread, b, false, args, kwargs)
+}
+
+func (m *impl) unit(thread *starlark.Thread, b *starlark.Builtin, user bool, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if !boot.InTask(thread) {
+		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
+	}
+	var (
+		name         string
+		enabled      bool
+		started      bool
+		daemonReload bool
+	)
+	if err := starlark.UnpackArgs(
+		b.Name(), args, kwargs,
+		"name", &name,
+		"enabled?", &enabled,
+		"started?", &started,
+		"daemon_reload?", &daemonReload,
+	); err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, fmt.Errorf("%s: name cannot be empty", b.Name())
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: "systemd " + scopeName(user) + " unit " + name,
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			needsChange := false
+			needsReload := false
+			needsEnable := false
+			needsStart := false
+			if daemonReload {
+				var err error
+				needsReload, err = unitNeedsReload(ctx, m.rt, user, name)
+				if err != nil {
+					return "", err
+				}
+				needsChange = needsChange || needsReload
+			}
+			if enabled {
+				ok, err := systemctlQuiet(ctx, m.rt, user, "is-enabled", name)
+				if err != nil {
+					return "", err
+				}
+				needsEnable = !ok
+				needsChange = needsChange || needsEnable
+			}
+			if started {
+				ok, err := systemctlQuiet(ctx, m.rt, user, "is-active", name)
+				if err != nil {
+					return "", err
+				}
+				needsStart = !ok
+				needsChange = needsChange || needsStart
+			}
+			if !needsChange {
+				return boot.ResultSkip, nil
+			}
+			if dryRun {
+				return boot.ResultChange, nil
+			}
+			if needsReload {
+				if err := runSystemctl(ctx, m.rt, user, "daemon-reload"); err != nil {
+					return "", err
+				}
+			}
+			if needsEnable || needsStart {
+				args := []string{"enable"}
+				if needsStart {
+					args = append(args, "--now")
+				}
+				args = append(args, name)
+				if err := runSystemctl(ctx, m.rt, user, args...); err != nil {
+					return "", err
+				}
+			}
+			return boot.ResultChange, nil
+		},
+	})
+	return starlark.None, nil
+}
+
+func unitNeedsReload(ctx context.Context, rt *boot.Runtime, user bool, name string) (bool, error) {
+	cmd := systemctlCommand(ctx, rt, user, "show", name, "--property=NeedDaemonReload", "--value")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return false, err
+		}
+		return false, fmt.Errorf("%w:\n%s", err, msg)
+	}
+	switch strings.TrimSpace(string(out)) {
+	case "yes":
+		return true, nil
+	case "no", "":
+		return false, nil
+	default:
+		return true, nil
+	}
+}
+
+func systemctlQuiet(ctx context.Context, rt *boot.Runtime, user bool, args ...string) (bool, error) {
+	cmd := systemctlCommand(ctx, rt, user, args...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+	status := strings.TrimSpace(string(out))
+	if status == "disabled" || status == "inactive" || status == "failed" {
+		return false, nil
+	}
+	if strings.Contains(string(out), "could not be found") {
+		return false, nil
+	}
+	if _, ok := err.(*exec.ExitError); ok {
+		return false, nil
+	}
+	return false, err
+}
+
+func runSystemctl(ctx context.Context, rt *boot.Runtime, user bool, args ...string) error {
+	cmd := systemctlCommand(ctx, rt, user, args...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	msg := strings.TrimSpace(string(out))
+	if msg == "" {
+		return err
+	}
+	return fmt.Errorf("%w:\n%s", err, msg)
+}
+
+func systemctlCommand(ctx context.Context, rt *boot.Runtime, user bool, args ...string) *exec.Cmd {
+	argv := []string{"systemctl"}
+	if user {
+		argv = append(argv, "--user")
+	} else if rt.NeedsSudo() {
+		argv = []string{"sudo", "systemctl"}
+	}
+	argv = append(argv, args...)
+	return exec.CommandContext(ctx, argv[0], argv[1:]...)
+}
+
+func scopeName(user bool) string {
+	if user {
+		return "user"
+	}
+	return "system"
+}

--- a/cmd/boot/internal/systemd/systemd_test.go
+++ b/cmd/boot/internal/systemd/systemd_test.go
@@ -1,0 +1,103 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package systemd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+	"go.starlark.net/starlark"
+)
+
+func TestUserUnitSkipsWhenCurrent(t *testing.T) {
+	bin := t.TempDir()
+	log := filepath.Join(t.TempDir(), "systemctl.log")
+	testutil.WriteCommand(t, bin, "systemctl", `#!/bin/sh
+echo "$@" >> "`+log+`"
+case "$*" in
+"--user show periodic.timer --property=NeedDaemonReload --value") echo no; exit 0 ;;
+"--user is-enabled periodic.timer") echo enabled; exit 0 ;;
+"--user is-active periodic.timer") echo active; exit 0 ;;
+*) exit 1 ;;
+esac
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	task, thread := testutil.TaskThread("test")
+	m := &impl{}
+	_, err := m.userUnit(thread, starlark.NewBuiltin("systemd.user_unit", m.userUnit), nil, []starlark.Tuple{
+		{starlark.String("name"), starlark.String("periodic.timer")},
+		{starlark.String("enabled"), starlark.True},
+		{starlark.String("started"), starlark.True},
+		{starlark.String("daemon_reload"), starlark.True},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := task.Actions[0].Apply(context.Background(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != boot.ResultSkip {
+		t.Fatalf("result = %s, want %s", got, boot.ResultSkip)
+	}
+	out, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "daemon-reload") || strings.Contains(string(out), "enable --now") {
+		t.Fatalf("dry run invoked changing command:\n%s", out)
+	}
+}
+
+func TestUserUnitChangesWhenReloadNeeded(t *testing.T) {
+	bin := t.TempDir()
+	log := filepath.Join(t.TempDir(), "systemctl.log")
+	testutil.WriteCommand(t, bin, "systemctl", `#!/bin/sh
+echo "$@" >> "`+log+`"
+case "$*" in
+"--user show periodic.timer --property=NeedDaemonReload --value") echo yes; exit 0 ;;
+"--user is-enabled periodic.timer") echo enabled; exit 0 ;;
+"--user is-active periodic.timer") echo active; exit 0 ;;
+"--user daemon-reload") exit 0 ;;
+"--user enable --now periodic.timer") exit 0 ;;
+*) exit 1 ;;
+esac
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	task, thread := testutil.TaskThread("test")
+	m := &impl{}
+	_, err := m.userUnit(thread, starlark.NewBuiltin("systemd.user_unit", m.userUnit), nil, []starlark.Tuple{
+		{starlark.String("name"), starlark.String("periodic.timer")},
+		{starlark.String("enabled"), starlark.True},
+		{starlark.String("started"), starlark.True},
+		{starlark.String("daemon_reload"), starlark.True},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := task.Actions[0].Apply(context.Background(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != boot.ResultChange {
+		t.Fatalf("result = %s, want %s", got, boot.ResultChange)
+	}
+	out, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "--user daemon-reload") {
+		t.Fatalf("daemon-reload was not invoked:\n%s", out)
+	}
+}

--- a/cmd/boot/internal/testutil/testutil.go
+++ b/cmd/boot/internal/testutil/testutil.go
@@ -1,0 +1,51 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package testutil provides helpers for boot module tests.
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+// TaskThread returns a task and thread associated with each other.
+func TaskThread(id string) (*boot.Task, *starlark.Thread) {
+	task := &boot.Task{ID: id}
+	thread := &starlark.Thread{Name: id}
+	boot.SetTask(thread, task)
+	return task, thread
+}
+
+// WriteCommand writes an executable script into dir.
+func WriteCommand(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// RunGit runs git in dir and fails the test on error.
+func RunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	RunGitOutput(t, dir, args...)
+}
+
+// RunGitOutput runs git in dir and returns its combined output.
+func RunGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return string(out)
+}

--- a/cmd/boot/main.go
+++ b/cmd/boot/main.go
@@ -1,0 +1,198 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.astrophena.name/base/cli"
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	bootconsent "go.astrophena.name/tools/cmd/boot/internal/consent"
+	bootenv "go.astrophena.name/tools/cmd/boot/internal/env"
+	bootfetch "go.astrophena.name/tools/cmd/boot/internal/fetch"
+	bootflatpak "go.astrophena.name/tools/cmd/boot/internal/flatpak"
+	bootfs "go.astrophena.name/tools/cmd/boot/internal/fs"
+	bootgit "go.astrophena.name/tools/cmd/boot/internal/git"
+	bootgo "go.astrophena.name/tools/cmd/boot/internal/golang"
+	bootpkg "go.astrophena.name/tools/cmd/boot/internal/packages"
+	bootpacman "go.astrophena.name/tools/cmd/boot/internal/pacman"
+	bootrescue "go.astrophena.name/tools/cmd/boot/internal/rescue"
+	bootshell "go.astrophena.name/tools/cmd/boot/internal/shell"
+	bootssh "go.astrophena.name/tools/cmd/boot/internal/ssh"
+	bootsystemd "go.astrophena.name/tools/cmd/boot/internal/systemd"
+	"go.astrophena.name/tools/internal/filelock"
+
+	"golang.org/x/term"
+)
+
+const defaultEntry = "BOOT.star"
+
+func main() { cli.Main(new(app)) }
+
+type app struct {
+	root        string
+	entry       string
+	failFast    bool
+	only        multiFlag
+	skip        multiFlag
+	tags        multiFlag
+	dryRun      bool
+	verbose     bool
+	json        bool
+	concurrency int
+}
+
+func (a *app) Flags(fs *flag.FlagSet) {
+	fs.StringVar(&a.root, "C", ".", "Run as if boot was started in `dir`.")
+	fs.StringVar(&a.entry, "f", defaultEntry, "Recipe entrypoint `file`.")
+	fs.BoolVar(&a.failFast, "fail-fast", false, "Stop on the first failed task.")
+	fs.BoolVar(&a.dryRun, "dry-run", false, "Alias for plan: print actions without applying changes.")
+	fs.BoolVar(&a.verbose, "verbose", false, "Print detailed action output when applying changes.")
+	fs.BoolVar(&a.json, "json", false, "Print machine-readable JSON output.")
+	fs.Var(&a.only, "only", "Run only the specified task ID. May be repeated.")
+	fs.Var(&a.skip, "skip", "Skip the specified task ID. May be repeated.")
+	fs.Var(&a.tags, "tag", "Run tasks with the specified tag. May be repeated.")
+	fs.IntVar(&a.concurrency, "j", 1, "Number of tasks to run in parallel.")
+}
+
+func (a *app) Run(ctx context.Context) error {
+	env := cli.GetEnv(ctx)
+	if len(env.Args) != 1 {
+		return fmt.Errorf("%w: command is required\nusage: boot [flags...] <list|plan|apply>\nrun 'boot -help' for details", cli.ErrInvalidArgs)
+	}
+
+	command := env.Args[0]
+	if a.dryRun {
+		command = "plan"
+	}
+
+	engine, err := a.engine(env)
+	if err != nil {
+		return err
+	}
+	if err := engine.Load(ctx); err != nil {
+		return fmt.Errorf("%w: %v", cli.ErrInvalidArgs, err)
+	}
+
+	selection := boot.Selection{
+		Only: a.only,
+		Skip: a.skip,
+		Tags: a.tags,
+	}
+	switch command {
+	case "list":
+		return engine.List(env.Stdout, selection)
+	case "plan", "check":
+		return engine.Run(ctx, env.Stdout, selection, boot.RunOptions{
+			DryRun:      true,
+			FailFast:    a.failFast,
+			Interactive: interactive(env),
+			Concurrency: a.concurrency,
+			Color:       env.Getenv("NO_COLOR") == "",
+			Verbose:     a.verbose,
+			JSON:        a.json,
+		})
+	case "apply":
+		lock, err := acquireLock(rootLockPath(engine.Runtime.Root))
+		if err != nil {
+			return err
+		}
+		defer lock.Release()
+		return engine.Run(ctx, env.Stdout, selection, boot.RunOptions{
+			FailFast:    a.failFast,
+			Interactive: interactive(env),
+			Concurrency: a.concurrency,
+			Color:       env.Getenv("NO_COLOR") == "",
+			Verbose:     a.verbose,
+			JSON:        a.json,
+		})
+	default:
+		return fmt.Errorf("%w: no such command %q", cli.ErrInvalidArgs, command)
+	}
+}
+
+func rootLockPath(root string) string {
+	sum := sha256.Sum256([]byte(root))
+	return filepath.Join(os.TempDir(), "boot-"+hex.EncodeToString(sum[:8])+".lock")
+}
+
+func acquireLock(path string) (filelock.Lock, error) {
+	lock, err := filelock.Acquire(path, fmt.Sprintf("pid=%d\n", os.Getpid()))
+	if err == nil {
+		return lock, nil
+	}
+	if errors.Is(err, filelock.ErrAlreadyLocked) {
+		return nil, fmt.Errorf("another boot apply is already running for this recipe")
+	}
+	return nil, err
+}
+
+func interactive(env *cli.Env) bool {
+	if env.Getenv("CI") == "true" {
+		return false
+	}
+	in, inOK := env.Stdin.(*os.File)
+	out, outOK := env.Stdout.(*os.File)
+	return inOK && outOK && term.IsTerminal(int(in.Fd())) && term.IsTerminal(int(out.Fd()))
+}
+
+func (a *app) engine(env *cli.Env) (*boot.Engine, error) {
+	root, err := filepath.Abs(a.root)
+	if err != nil {
+		return nil, err
+	}
+	home := env.Getenv("HOME")
+	if home == "" {
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+	}
+	rt := &boot.Runtime{
+		Root:   root,
+		Home:   home,
+		Getenv: env.Getenv,
+		Stdin:  env.Stdin,
+		Stdout: env.Stdout,
+	}
+	return &boot.Engine{
+		Runtime: rt,
+		Entry:   a.entry,
+		Modules: []boot.Module{
+			bootconsent.Module(),
+			bootenv.Module(),
+			bootfetch.Module(),
+			bootflatpak.Module(),
+			bootfs.Module(),
+			bootpkg.Module(),
+			bootpacman.Module(),
+			bootshell.Module(),
+			bootgit.Module(),
+			bootgo.Module(),
+			bootrescue.Module(),
+			bootssh.Module(),
+			bootsystemd.Module(),
+		},
+	}, nil
+}
+
+type multiFlag []string
+
+func (f *multiFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *multiFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}

--- a/cmd/boot/main_test.go
+++ b/cmd/boot/main_test.go
@@ -1,0 +1,214 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.astrophena.name/base/cli"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		args         []string
+		setup        func(t *testing.T, root string)
+		noRecipe     bool
+		wantErr      error
+		wantErrText  string
+		wantInOutput []string
+		wantMissing  []string
+		check        func(t *testing.T, root string)
+	}{
+		"missing command": {
+			args:        nil,
+			wantErr:     cli.ErrInvalidArgs,
+			wantErrText: "usage: boot [flags...] <list|plan|apply>",
+		},
+		"missing default recipe": {
+			args:        []string{"plan"},
+			noRecipe:    true,
+			wantErr:     cli.ErrInvalidArgs,
+			wantErrText: "recipe BOOT.star not found",
+		},
+		"list": {
+			args: []string{"list"},
+			wantInOutput: []string{
+				"ID",
+				"NAME",
+				"TAGS",
+				"dotfiles",
+				"Link dotfiles",
+				"filesystem,shell",
+				"cache",
+				"Create cache",
+			},
+		},
+		"plan does not modify filesystem": {
+			args: []string{"plan"},
+			wantInOutput: []string{
+				"[1/2] Planning task dotfiles: Link dotfiles",
+				"change dotfiles: dir ",
+				"change dotfiles: symlink ",
+				"summary: 2 tasks, 3 actions, 3 would change, 0 skipped, 0 warnings, 0 failed",
+			},
+			check: func(t *testing.T, root string) {
+				t.Helper()
+				if _, err := os.Lstat(filepath.Join(root, "home", ".bashrc")); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("planned symlink exists: %v", err)
+				}
+			},
+		},
+		"apply is idempotent": {
+			args: []string{"apply"},
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(root, "home", "local", "data", "bash"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(filepath.Join(root, "bash", "rc"), filepath.Join(root, "home", ".bashrc")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantInOutput: []string{
+				"Report:",
+				"Boot ran 2 tasks and checked 3 actions.",
+				"It changed 1 action and skipped 2 actions.",
+				"No actions failed.",
+			},
+			wantMissing: []string{"summary:", "change dotfiles:", "skip dotfiles:"},
+		},
+		"apply verbose prints actions": {
+			args: []string{"-verbose", "apply"},
+			wantInOutput: []string{
+				"[1/2] Applying task dotfiles: Link dotfiles",
+				"change dotfiles: dir ",
+				"change dotfiles: symlink ",
+				"Report:",
+			},
+			check: func(t *testing.T, root string) {
+				t.Helper()
+				if _, err := os.Lstat(filepath.Join(root, "home", ".bashrc")); err != nil {
+					t.Fatalf("applied symlink missing: %v", err)
+				}
+			},
+		},
+		"only filters tasks": {
+			args: []string{"-only", "cache", "list"},
+			wantInOutput: []string{
+				"cache",
+				"Create cache",
+				"filesystem",
+			},
+			wantMissing: []string{
+				"dotfiles",
+				"Link dotfiles",
+			},
+		},
+		"tag filters tasks": {
+			args: []string{"-tag", "shell", "list"},
+			wantInOutput: []string{
+				"dotfiles",
+				"Link dotfiles",
+				"filesystem,shell",
+			},
+			wantMissing: []string{
+				"cache",
+				"Create cache",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			if !tc.noRecipe {
+				writeRecipe(t, root)
+			}
+			if tc.setup != nil {
+				tc.setup(t, root)
+			}
+
+			var stdout, stderr bytes.Buffer
+			env := &cli.Env{
+				Args:   append([]string{"-C", root}, tc.args...),
+				Stdout: &stdout,
+				Stderr: &stderr,
+				Getenv: func(key string) string {
+					if key == "HOME" {
+						return filepath.Join(root, "home")
+					}
+					if key == "NO_COLOR" {
+						return "1"
+					}
+					return ""
+				},
+			}
+			err := cli.Run(cli.WithEnv(t.Context(), env), new(app))
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("got error %v, want %v\nstdout:\n%s\nstderr:\n%s", err, tc.wantErr, stdout.String(), stderr.String())
+			}
+			if tc.wantErrText != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErrText)) {
+				t.Fatalf("error does not contain %q: %v", tc.wantErrText, err)
+			}
+			for _, want := range tc.wantInOutput {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("stdout does not contain %q:\n%s", want, stdout.String())
+				}
+			}
+			for _, missing := range tc.wantMissing {
+				if strings.Contains(stdout.String(), missing) {
+					t.Errorf("stdout contains %q:\n%s", missing, stdout.String())
+				}
+			}
+			if tc.check != nil {
+				tc.check(t, root)
+			}
+		})
+	}
+}
+
+func writeRecipe(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "bash"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bash", "rc"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recipe := `# vim: ft=starlark shiftwidth=4
+
+def dotfiles():
+    fs.dir("~/local/data/bash")
+    fs.symlink("bash/rc", "~/.bashrc")
+
+def cache():
+    fs.dir("~/local/cache")
+
+task(
+    id="dotfiles",
+    name="Link dotfiles",
+    tags=["filesystem", "shell"],
+    run=dotfiles,
+)
+task(
+    id="cache",
+    name="Create cache",
+    tags=["filesystem"],
+    run=cache,
+)
+`
+	if err := os.WriteFile(filepath.Join(root, "BOOT.star"), []byte(recipe), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/boot/modules.md
+++ b/cmd/boot/modules.md
@@ -1,0 +1,214 @@
+# Starlark Environment
+
+These built-in functions and modules are available in the Starlark environment.
+
+## Built-ins
+
+### `fail(message)`
+
+Stop recipe or task execution with `message`.
+
+### `task(..., when = True)`
+
+Register a task. When `when` is false, the task is not registered; this is a
+small replacement for wrapping conditional machine tasks in extra Starlark
+control flow.
+
+## `consent`
+
+### `consent.require(message, default = False)`
+
+Ask the user for confirmation before continuing the current task. In dry-run
+mode this is reported as a planned change. In non-interactive mode, or when the
+answer is no, remaining actions in the task are skipped.
+
+## `env`
+
+### `env.command_exists(name)`
+
+Return whether `name` can be found in `PATH`.
+
+### `env.get(key, default = "")`
+
+Return the value of the environment variable `key`. If the variable is not set
+or is empty, return `default`.
+
+### `env.hostname()`
+
+Return the system host name.
+
+### `env.load_dir(path)`
+
+Load shell-style `*.conf` environment files from `path` in lexical order into
+the current process. Later commands inherit these variables.
+
+## `fs`
+
+### `fs.dir(path)`
+
+Ensure `path` exists as a directory.
+
+### `fs.symlink(source, target, backup = False)`
+
+Ensure `target` is a symbolic link to `source`. Relative sources are resolved
+against the recipe root; paths beginning with `~/` use `HOME`.
+
+### `fs.file(path, content, mode = 0o644)`
+
+Ensure `path` exists with the given content and mode.
+
+### `fs.template(path, template, values, mode = 0o644)`
+
+Render `template` to `path`, replacing `{{name}}` placeholders with values from
+the `values` dictionary.
+
+### `fs.sha256(path)`
+
+Return the SHA-256 digest of `path`.
+
+### `fs.newer(source, target)`
+
+Return whether `source` has a newer modification time than `target`, or whether
+`target` does not exist.
+
+### `fs.remove(path)`
+
+Ensure `path` does not exist (removes it if it does).
+
+### `fs.chmod(path, mode)`
+
+Ensure `path` has the given permission mode.
+
+### `fs.sync_tree(source, target, owner = "", group = "", sudo = False, only_if_exists = False)`
+
+Synchronize a directory tree with `rsync -a`. If `owner` or `group` is set,
+pass `--chown`. If `only_if_exists` is true, skip when `source` is missing.
+
+## `fetch`
+
+### `fetch.file(url, path, mode = 0o644, checksum = "")`
+
+Ensure `path` exists with the contents downloaded from `url`. If `checksum` is
+set, it must be a SHA-256 hex digest, optionally prefixed with `sha256:`.
+
+## `flatpak`
+
+### `flatpak.update()`
+
+Update Flatpak applications when updates are available. Skips when `flatpak`
+is not installed or no updates are pending.
+
+## `pkg`
+
+### `pkg.configure(manager)`
+
+Select the package manager. Supported values are `apt` and `pacman`. If this
+is not set, boot checks `BOOT_PACKAGE_MANAGER` and then detects `pacman` or `apt`
+from the host environment.
+
+### `pkg.install(packages)`
+
+Install missing packages. The package database is checked before invoking
+the package manager, so no-op runs are fast.
+
+### `pkg.update()`
+
+Update the package manager's database and upgrade installed packages.
+
+### `pkg.check_explicit_packages(packages)`
+
+Warn when explicitly installed native packages are not listed in `packages`, for
+package managers that can report manual/native package state.
+
+### `pkg.manager()`
+
+Return the selected or detected package manager name.
+
+## `pacman`
+
+### `pacman.check_orphans()`
+
+Warn when orphaned packages are installed.
+
+### `pacman.check_explicit_packages(packages)`
+
+Warn when explicitly installed native packages are not listed in `packages`.
+
+### `pacman.check_pacnew(prefs_etc)`
+
+Warn when `.pacnew` files exist under `/etc`, grouping files managed by
+`prefs_etc` separately from unmanaged files and showing short diffs.
+
+## `rescue`
+
+### `rescue.update(source, esp_dir = "/efi/EFI/Linux", keep = 3)`
+
+Build and install an Arch rescue image from `source` when the current ESP image
+is not from the current month. Signed images are installed with `sbctl`; old ESP
+images are pruned after `keep` entries.
+
+## `shell`
+
+### `shell.run(command, creates = "", only_if = "", cwd = "", sudo = False)`
+
+Run a shell command. If `creates` is set, the command is skipped if the
+path exists. If `only_if` is set, the command is run only if the `only_if`
+command succeeds (returns 0). If `cwd` is set, the command runs in that directory.
+If `sudo` is true, the command will be executed with elevated privileges via `sudo`.
+
+### `shell.output(command, cwd = "", sudo = False)`
+
+Run a shell command and return its standard output as a string. This is executed
+immediately during recipe evaluation, not during the apply phase. If `sudo` is true, 
+it executes with elevated privileges.
+
+## `systemd`
+
+### `systemd.system_unit(name, enabled = False, started = False, daemon_reload = False)`
+
+Ensure a system unit is enabled and/or started, optionally reloading system units
+first when systemd reports that a daemon reload is needed.
+
+### `systemd.user_unit(name, enabled = False, started = False, daemon_reload = False)`
+
+Ensure a user unit is enabled and/or started, optionally reloading user units
+first when systemd reports that a daemon reload is needed.
+
+## `git`
+
+### `git.clone(url, dest)`
+
+Ensure `url` is cloned to `dest`. Relative `dest` is resolved against the recipe
+root; paths beginning with `~/` use `HOME`.
+
+### `git.pull(dest)`
+
+Ensure the git repository at `dest` is up-to-date. It skips if the repository is dirty or has no upstream tracking branch.
+
+### `git.sync(url, dest)`
+
+Ensure `url` is cloned to `dest`, or fetch and fast-forward pull the existing
+repository when it is clean and has an upstream tracking branch.
+
+## `go`
+
+### `go.install(packages, cwd = "", ldflags = "-s -w -buildid=", trimpath = True)`
+
+Run `go install` separately for each package in the given list. Existing
+binaries are skipped when their embedded build information already matches the
+requested version. For `@latest`, boot compares the installed module version
+with the latest version reported by `go list -m`.
+
+### `go.install_local(package, cwd, fallback_latest = True, ldflags = "-s -w -buildid=", trimpath = True)`
+
+Run `go install` for `package` from `cwd` when that checkout exists. If
+`fallback_latest` is true and `cwd` does not exist, install `package@latest`.
+Local binaries are skipped when their embedded VCS revision matches the checkout
+HEAD and the checkout is clean.
+
+## `ssh`
+
+### `ssh.key(path, type = "ed25519", comment = "", passphrase = "")`
+
+Ensure an SSH key exists at `path`, generating it with `ssh-keygen` when missing.
+If `comment` is empty, the host name is used.

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,10 @@ require (
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/tailscale/sqlite v0.0.0-20260306200437-15a02b90c606
 	github.com/tobischo/gokeepasslib/v3 v3.6.2
-	go.astrophena.name/base v0.19.1
+	go.astrophena.name/base v0.21.0
 	go.starlark.net v0.0.0-20260326113308-fadfc96def35
+	golang.org/x/mod v0.35.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
 	rsc.io/markdown v0.0.0-20241212154241-6bf72452917f
 )
@@ -20,7 +22,7 @@ require (
 require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/PuerkitoBio/goquery v1.12.0 // indirect
-	github.com/a-h/templ v0.3.1001 // indirect
+	github.com/a-h/templ v0.3.1020 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/go4org/hashtriemap v0.0.0-20251130024219-545ba229f689 // indirect
@@ -34,9 +36,7 @@ require (
 	github.com/tobischo/argon2 v0.1.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260218203240-3dfff04db8fa // indirect
-	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
-github.com/a-h/templ v0.3.1001 h1:yHDTgexACdJttyiyamcTHXr2QkIeVF1MukLy44EAhMY=
-github.com/a-h/templ v0.3.1001/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
+github.com/a-h/templ v0.3.1020 h1:ypAT/L5ySWEnZ6Zft/5yfoWXYYkhFNvEFOeeqecg4tw=
+github.com/a-h/templ v0.3.1020/go.mod h1:A2DlK61v+K+NRoGnhmYbNYVmtYHcFO5/AisMvBdDxTM=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=
@@ -61,8 +61,8 @@ github.com/tobischo/gokeepasslib/v3 v3.6.2/go.mod h1:ga7HFqG0TZSLNao/QOnV2+yngkr
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
 github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.astrophena.name/base v0.19.1 h1:FT6H1vOiS2Hg1Thq3THdF+4YE9M7jSljbQL1XvwOvbA=
-go.astrophena.name/base v0.19.1/go.mod h1:H9hT1OxYVqImEfd+Hrmt0MPySOkXxuIBXeg8xOoAYKM=
+go.astrophena.name/base v0.21.0 h1:qWCa0nWi8O8BiTDQxIXRo+SIecQj4xAvmcMt2KyY+Ho=
+go.astrophena.name/base v0.21.0/go.mod h1:KHhS92wYEKGvkTYXssWdU5051pKedfxFsvfkbN19COc=
 go.starlark.net v0.0.0-20260326113308-fadfc96def35 h1:VYAqieSOJNxBDX8KJneTAwvdf4J4zRDE2u+UFXtt9h4=
 go.starlark.net v0.0.0-20260326113308-fadfc96def35/go.mod h1:Iue6g6iirlfLoVi/DYCi5/x0h/bAOuWF3dULTKpt2Vo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Add boot, a Starlark-based host setup tool for managing development environment state from idempotent recipe tasks.

The new command can list tasks, plan changes, run validation checks, apply actions, and emit JSON output for scripts. It includes task filtering, dependency ordering, sudo preparation, per-recipe apply locking, non-fatal warning results, and consent gates for operations such as package updates.

Boot ships with modules for common setup work: filesystem state and templates, package installation and drift checks, pacman maintenance checks, Flatpak updates, Git checkout sync, Go tool installation, fetches, shell commands, SSH key generation, systemd user/system units, and Arch rescue image refreshes with old mkosi.output pruning.

Also add command/module documentation, internal hacking notes, and focused tests for the runtime and modules.

Checks:
- go test ./cmd/boot ./cmd/boot/internal/...
- go tool pre-commit