### PR TITLE
cmd/boot: improve plan mode and consent output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Follow the Go style for commit messages.
 - Write meaningful comments. Avoid stating the obvious.
   - **Bad:** `// WriteFile writes a file.`
   - **Good:** `// WriteFile writes data to a file, creating it if necessary.`
+- When documenting shell commands, prefix commands with `$` for commands run as a normal user and `#` for commands run as root (using `sudo` or similar).
 
 ## Dependencies
 

--- a/cmd/boot/internal/README.md
+++ b/cmd/boot/internal/README.md
@@ -80,8 +80,8 @@ the code fragile or much larger.
 Start with a focused recipe and task selection:
 
 ```sh
-go run ./cmd/boot -C ~/code/prefs -only setup_packages plan
-go run ./cmd/boot -C ~/code/prefs -only setup_packages -verbose apply
+$ go run ./cmd/boot -only setup_packages plan
+$ go run ./cmd/boot -only setup_packages -verbose apply
 ```
 
 Use `plan` to verify the action list and idempotency checks. Use `-verbose
@@ -120,21 +120,5 @@ For command-based modules, create small executable shell scripts with
 Before submitting changes, run from the repository root:
 
 ```sh
-go tool pre-commit
+$ go tool pre-commit
 ```
-
-## Recipe Compatibility
-
-Boot currently targets the prefs setup recipes, so compatibility with the old
-`automation/setup` behavior matters. Be careful around:
-
-- package updates, which may need explicit consent;
-- maintenance checks, which should warn unless the recipe intentionally wants a
-  hard failure;
-- environment loading before tools that rely on `GOBIN`, `GOPATH`, or XDG
-  variables;
-- dry-run behavior for system modules.
-
-When replacing old setup behavior, read the old Python task and port the
-observable behavior first. Then simplify only when the new behavior is
-intentional and documented.

--- a/cmd/boot/internal/consent/consent.go
+++ b/cmd/boot/internal/consent/consent.go
@@ -57,7 +57,8 @@ func (m *impl) require(thread *starlark.Thread, b *starlark.Builtin, args starla
 	}
 
 	boot.AddAction(thread, boot.Action{
-		Summary: "confirm: " + message,
+		Summary:   "would ask for consent: " + message,
+		IsConsent: true,
 		Apply: func(_ context.Context, dryRun bool) (boot.Result, error) {
 			if dryRun {
 				return boot.ResultChange, nil

--- a/cmd/boot/internal/engine.go
+++ b/cmd/boot/internal/engine.go
@@ -49,8 +49,9 @@ type Task struct {
 
 // Action is an idempotent operation emitted by a task.
 type Action struct {
-	Summary string
-	Apply   func(context.Context, bool) (Result, error)
+	Summary   string
+	Apply     func(context.Context, bool) (Result, error)
+	IsConsent bool
 }
 
 // Result describes what an action did.
@@ -159,7 +160,7 @@ func (e *Engine) Run(ctx context.Context, w io.Writer, selection Selection, opts
 		return e.runJSON(ctx, w, selection, opts)
 	}
 	if opts.DryRun {
-		return e.plan(ctx, w, selection, opts)
+		return e.RunPlan(ctx, w, selection, opts)
 	}
 	if opts.Verbose {
 		return e.applyVerbose(ctx, w, selection, opts)
@@ -167,7 +168,74 @@ func (e *Engine) Run(ctx context.Context, w io.Writer, selection Selection, opts
 	return e.apply(ctx, w, selection, opts)
 }
 
-func (e *Engine) plan(ctx context.Context, w io.Writer, selection Selection, opts RunOptions) error {
+func (e *Engine) prepare(ctx context.Context, tasks []*Task, opts RunOptions) (planned map[string]bool, summary Summary, failures []failure, stopOnError bool) {
+	planned = make(map[string]bool)
+	summary.Tasks = len(tasks)
+
+	for _, task := range tasks {
+		task.Actions = nil
+		thread := &starlark.Thread{Name: "boot:" + task.ID}
+		SetTask(thread, task)
+		if _, err := starlark.Call(thread, task.Run, nil, nil); err != nil {
+			if !task.ContinueOnError {
+				stopOnError = true
+			}
+			summary.Failed++
+			failures = append(failures, failure{TaskID: task.ID, TaskName: task.Name, Err: err})
+			if opts.FailFast && !task.ContinueOnError {
+				break
+			}
+			continue
+		}
+		if opts.Interactive && !opts.DryRun {
+			stop := false
+			for i := 0; i < len(task.Actions); i++ {
+				action := task.Actions[i]
+				if action.IsConsent {
+					summary.Actions++
+					result, err := action.Apply(ctx, false)
+					if err != nil {
+						if !task.ContinueOnError {
+							stopOnError = true
+						}
+						summary.Failed++
+						failures = append(failures, failure{TaskID: task.ID, TaskName: task.Name, Action: action.Summary, Err: err})
+						if opts.FailFast && !task.ContinueOnError {
+							stop = true
+							break
+						}
+						continue
+					}
+					if result == ResultSkip || result == ResultStop {
+						summary.Skipped++
+					} else if result == ResultChange {
+						summary.Changed++
+					} else if result == ResultWarn {
+						summary.Warnings++
+					}
+					if result == ResultStop {
+						task.Actions = nil
+						stop = true
+						break
+					}
+					task.Actions = slices.Delete(task.Actions, i, i+1)
+					i--
+				}
+			}
+			if stop && opts.FailFast && (len(tasks) > 0 && !tasks[0].ContinueOnError) { // approximated
+				break
+			}
+			if stop {
+				continue
+			}
+		}
+		planned[task.ID] = true
+	}
+	return planned, summary, failures, stopOnError
+}
+
+// RunPlan plans the selected tasks, evaluating actions without applying changes.
+func (e *Engine) RunPlan(ctx context.Context, w io.Writer, selection Selection, opts RunOptions) error {
 	tasks, err := e.Selected(selection)
 	if err != nil {
 		return err
@@ -242,21 +310,20 @@ func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, op
 	if err := e.prepareSudo(ctx, tasks); err != nil {
 		return err
 	}
-	summary := Summary{
-		Tasks: len(tasks),
+
+	planned, summary, failures, stopOnError := e.prepare(ctx, tasks, opts)
+	hadFailures := len(failures) > 0
+
+	if stopOnError && opts.FailFast {
+		e.printReport(w, summary, false)
+		e.printFailures(w, failures)
+		return errors.New("one or more tasks failed")
 	}
 
 	concurrency := max(opts.Concurrency, 1)
 
 	pb := progressbar.New(w, len(tasks), opts.Interactive)
 	pb.Start()
-
-	var (
-		mu          sync.Mutex
-		hadFailures bool
-		stopOnError bool
-		failures    []failure
-	)
 
 	doneCh := make(map[string]chan struct{})
 	for _, task := range tasks {
@@ -265,6 +332,8 @@ func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, op
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(concurrency)
+
+	var mu sync.Mutex
 
 	for _, task := range tasks {
 		g.Go(func() error {
@@ -281,35 +350,14 @@ func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, op
 			}
 
 			mu.Lock()
-			if stopOnError && opts.FailFast {
+			if !planned[task.ID] || (stopOnError && opts.FailFast) {
 				mu.Unlock()
+				pb.Increment()
 				return nil
 			}
 			mu.Unlock()
 
-			task.Actions = nil
-
 			pb.SetTitle(task.Name)
-			thread := &starlark.Thread{Name: "boot:" + task.ID}
-			SetTask(thread, task)
-			_, err := starlark.Call(thread, task.Run, nil, nil)
-			if err != nil {
-				mu.Lock()
-				hadFailures = true
-				if !task.ContinueOnError {
-					stopOnError = true
-				}
-				summary.Failed++
-				failures = append(failures, failure{TaskID: task.ID, TaskName: task.Name, Err: err})
-				mu.Unlock()
-
-				if opts.FailFast && !task.ContinueOnError {
-					pb.Increment()
-					return err
-				}
-				pb.Increment()
-				return nil
-			}
 
 			for _, action := range task.Actions {
 				mu.Lock()
@@ -388,23 +436,20 @@ func (e *Engine) applyVerbose(ctx context.Context, w io.Writer, selection Select
 	if err := e.prepareSudo(ctx, tasks); err != nil {
 		return err
 	}
-	summary := Summary{Tasks: len(tasks)}
-	var failures []failure
+
+	planned, summary, failures, stopOnError := e.prepare(ctx, tasks, opts)
+	if stopOnError && opts.FailFast {
+		e.printReport(w, summary, false)
+		e.printFailures(w, failures)
+		return errors.New("one or more tasks failed")
+	}
 
 	for i, task := range tasks {
-		stop := false
-		fmt.Fprintf(w, "[%d/%d] Applying task %s: %s\n", i+1, len(tasks), task.ID, task.Name)
-		task.Actions = nil
-		thread := &starlark.Thread{Name: "boot:" + task.ID}
-		SetTask(thread, task)
-		if _, err := starlark.Call(thread, task.Run, nil, nil); err != nil {
-			summary.Failed++
-			failures = append(failures, failure{TaskID: task.ID, TaskName: task.Name, Err: err})
-			if opts.FailFast && !task.ContinueOnError {
-				break
-			}
+		if !planned[task.ID] {
 			continue
 		}
+		stop := false
+		fmt.Fprintf(w, "[%d/%d] Applying task %s: %s\n", i+1, len(tasks), task.ID, task.Name)
 		for _, action := range task.Actions {
 			summary.Actions++
 			result, err := action.Apply(ctx, false)
@@ -581,17 +626,21 @@ func (e *Engine) runJSON(ctx context.Context, w io.Writer, selection Selection, 
 		}
 	}
 
-	report := jsonRun{DryRun: opts.DryRun, Summary: Summary{Tasks: len(tasks)}}
+	planned, summary, failures, stopOnError := e.prepare(ctx, tasks, opts)
+	report := jsonRun{DryRun: opts.DryRun, Summary: summary}
+	for _, f := range failures {
+		report.Actions = append(report.Actions, jsonAction{TaskID: f.TaskID, TaskName: f.TaskName, Error: f.Err.Error()})
+	}
+
+	if stopOnError && opts.FailFast {
+		if err := json.NewEncoder(w).Encode(report); err != nil {
+			return err
+		}
+		return errors.New("one or more tasks failed")
+	}
+
 	for _, task := range tasks {
-		task.Actions = nil
-		thread := &starlark.Thread{Name: "boot:" + task.ID}
-		SetTask(thread, task)
-		if _, err := starlark.Call(thread, task.Run, nil, nil); err != nil {
-			report.Summary.Failed++
-			report.Actions = append(report.Actions, jsonAction{TaskID: task.ID, TaskName: task.Name, Error: err.Error()})
-			if opts.FailFast && !task.ContinueOnError {
-				break
-			}
+		if !planned[task.ID] {
 			continue
 		}
 		stop := false

--- a/cmd/boot/internal/engine_test.go
+++ b/cmd/boot/internal/engine_test.go
@@ -114,8 +114,14 @@ func TestApplyVerboseFailFastStopsAfterActionFailure(t *testing.T) {
 		{
 			ID:   "second",
 			Name: "second",
-			Run: starlark.NewBuiltin("second", func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
-				ranSecond = true
+			Run: starlark.NewBuiltin("second", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+				AddAction(thread, Action{
+					Summary: "second",
+					Apply: func(context.Context, bool) (Result, error) {
+						ranSecond = true
+						return ResultSkip, nil
+					},
+				})
 				return starlark.None, nil
 			}),
 		},
@@ -127,7 +133,7 @@ func TestApplyVerboseFailFastStopsAfterActionFailure(t *testing.T) {
 		t.Fatal("Run succeeded, want failure")
 	}
 	if ranSecond {
-		t.Fatal("second task ran after action failure")
+		t.Fatal("second task actions ran after action failure")
 	}
 }
 

--- a/cmd/boot/internal/env/doc.go
+++ b/cmd/boot/internal/env/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package env provides boot Starlark primitives for environment variables.
+package env

--- a/cmd/boot/internal/flatpak/doc.go
+++ b/cmd/boot/internal/flatpak/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package flatpak provides boot Starlark primitives for Flatpak packages.
+package flatpak

--- a/cmd/boot/internal/git/doc.go
+++ b/cmd/boot/internal/git/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package git provides boot Starlark primitives for Git repositories.
+package git

--- a/cmd/boot/internal/golang/golang.go
+++ b/cmd/boot/internal/golang/golang.go
@@ -324,6 +324,7 @@ func newLatestCache(modules []string) *latestCache {
 	return &latestCache{modules: modules}
 }
 
+// Get returns the latest module info for the given module, using cached values if available.
 func (c *latestCache) Get(ctx context.Context, module string) (moduleInfo, error) {
 	c.once.Do(func() {
 		c.fetch(ctx)

--- a/cmd/boot/internal/pacman/doc.go
+++ b/cmd/boot/internal/pacman/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package pacman provides boot Starlark primitives for the Pacman package manager.
+package pacman

--- a/cmd/boot/internal/pacman/pacman.go
+++ b/cmd/boot/internal/pacman/pacman.go
@@ -121,11 +121,11 @@ func (m *impl) checkPacnew(thread *starlark.Thread, b *starlark.Builtin, args st
 	if !boot.InTask(thread) {
 		return nil, fmt.Errorf("%s: can only be called from a task", b.Name())
 	}
-	var prefsEtc string
-	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "prefs_etc", &prefsEtc); err != nil {
+	var managedEtc string
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "managed_etc", &managedEtc); err != nil {
 		return nil, err
 	}
-	prefsEtc = m.rt.ResolveSource(prefsEtc)
+	managedEtc = m.rt.ResolveSource(managedEtc)
 
 	boot.AddAction(thread, boot.Action{
 		Summary: "check pacman .pacnew files",
@@ -145,7 +145,7 @@ func (m *impl) checkPacnew(thread *starlark.Thread, b *starlark.Builtin, args st
 					unmanaged = append(unmanaged, path)
 					continue
 				}
-				if _, err := os.Stat(filepath.Join(prefsEtc, rel)); err == nil {
+				if _, err := os.Stat(filepath.Join(managedEtc, rel)); err == nil {
 					managed = append(managed, path)
 				} else {
 					unmanaged = append(unmanaged, path)
@@ -155,7 +155,7 @@ func (m *impl) checkPacnew(thread *starlark.Thread, b *starlark.Builtin, args st
 			var buf bytes.Buffer
 			fmt.Fprintln(&buf, ".pacnew files found")
 			if len(managed) > 0 {
-				fmt.Fprintln(&buf, "managed by prefs:")
+				fmt.Fprintln(&buf, "managed by recipe:")
 				fmt.Fprintln(&buf, bulletList(managed))
 				fmt.Fprintln(&buf, pacnewDiffs(ctx, managed))
 			}

--- a/cmd/boot/internal/rescue/doc.go
+++ b/cmd/boot/internal/rescue/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package rescue provides boot Starlark primitives for rescue system management.
+package rescue

--- a/cmd/boot/internal/shell/doc.go
+++ b/cmd/boot/internal/shell/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package shell provides boot Starlark primitives for running shell commands.
+package shell

--- a/cmd/boot/internal/shell/shell.go
+++ b/cmd/boot/internal/shell/shell.go
@@ -83,6 +83,9 @@ func (m *impl) run(thread *starlark.Thread, b *starlark.Builtin, args starlark.T
 			}
 
 			if onlyIf != "" {
+				if dryRun && sudo && m.rt.NeedsSudo() {
+					return boot.ResultChange, nil
+				}
 				var cmd *exec.Cmd
 				if sudo && m.rt.NeedsSudo() {
 					cmd = exec.CommandContext(ctx, "sudo", "sh", "-c", onlyIf)

--- a/cmd/boot/internal/systemd/doc.go
+++ b/cmd/boot/internal/systemd/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package systemd provides boot Starlark primitives for systemd services.
+package systemd

--- a/cmd/boot/modules.md
+++ b/cmd/boot/modules.md
@@ -134,10 +134,10 @@ Warn when orphaned packages are installed.
 
 Warn when explicitly installed native packages are not listed in `packages`.
 
-### `pacman.check_pacnew(prefs_etc)`
+### `pacman.check_pacnew(managed_etc)`
 
 Warn when `.pacnew` files exist under `/etc`, grouping files managed by
-`prefs_etc` separately from unmanaged files and showing short diffs.
+`managed_etc` separately from unmanaged files and showing short diffs.
 
 ## `rescue`
 


### PR DESCRIPTION
Change the consent action summary to indicate that it 'would ask for consent'
instead of 'confirm:' in plan mode, preventing confusion about whether
user input is required during a dry run.

Also include improvements to the engine's plan mode and documentation.

Assisted-by: Gemini CLI
