### PR TITLE
cmd/boot: make maintenance actions idempotent

### DIFF
--- a/cmd/boot/internal/consent/consent_test.go
+++ b/cmd/boot/internal/consent/consent_test.go
@@ -5,7 +5,6 @@
 package consent
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -64,7 +63,7 @@ func TestRequire(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := task.Actions[0].Apply(context.Background(), tc.dryRun)
+			got, err := task.Actions[0].Apply(t.Context(), tc.dryRun)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/boot/internal/engine.go
+++ b/cmd/boot/internal/engine.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"text/tabwriter"
 
 	"go.astrophena.name/base/cli/progressbar"
@@ -52,6 +53,10 @@ type Action struct {
 	Summary   string
 	Apply     func(context.Context, bool) (Result, error)
 	IsConsent bool
+	// RequiresSudo marks an action as needing sudo even in dry-run mode.
+	RequiresSudo bool
+	// Concurrent marks an action as eligible to run in parallel with adjacent concurrent actions.
+	Concurrent bool
 }
 
 // Result describes what an action did.
@@ -206,11 +211,12 @@ func (e *Engine) prepare(ctx context.Context, tasks []*Task, opts RunOptions) (p
 						}
 						continue
 					}
-					if result == ResultSkip || result == ResultStop {
+					switch result {
+					case ResultSkip, ResultStop:
 						summary.Skipped++
-					} else if result == ResultChange {
+					case ResultChange:
 						summary.Changed++
-					} else if result == ResultWarn {
+					case ResultWarn:
 						summary.Warnings++
 					}
 					if result == ResultStop {
@@ -240,22 +246,27 @@ func (e *Engine) RunPlan(ctx context.Context, w io.Writer, selection Selection, 
 	if err != nil {
 		return err
 	}
-	summary := Summary{Tasks: len(tasks)}
+	if opts.FailFast {
+		return e.runPlanSequential(ctx, w, tasks, opts)
+	}
+	planned, summary, failures, stopOnError := e.prepare(ctx, tasks, opts)
+	if err := newSudoPrompter(e).prepare(ctx, w, tasks); err != nil {
+		return err
+	}
 
 	for i, task := range tasks {
-		stop := false
-		fmt.Fprintf(w, "[%d/%d] Planning task %s: %s\n", i+1, len(tasks), task.ID, task.Name)
-		task.Actions = nil
-		thread := &starlark.Thread{Name: "boot:" + task.ID}
-		SetTask(thread, task)
-		if _, err := starlark.Call(thread, task.Run, nil, nil); err != nil {
-			summary.Failed++
-			fmt.Fprintf(w, "%s %s: %v\n", e.color("fail", colorRed), task.ID, err)
-			if opts.FailFast && !task.ContinueOnError {
+		if !planned[task.ID] {
+			if failure, ok := taskFailure(failures, task); ok {
+				fmt.Fprintf(w, "[%d/%d] Planning task %s: %s\n", i+1, len(tasks), task.ID, task.Name)
+				fmt.Fprintf(w, "%s %s: %v\n", e.color("fail", colorRed), task.ID, failure.Err)
+			}
+			if stopOnError && opts.FailFast {
 				break
 			}
 			continue
 		}
+		stop := false
+		fmt.Fprintf(w, "[%d/%d] Planning task %s: %s\n", i+1, len(tasks), task.ID, task.Name)
 		for _, action := range task.Actions {
 			summary.Actions++
 			result, err := action.Apply(ctx, true)
@@ -274,11 +285,90 @@ func (e *Engine) RunPlan(ctx context.Context, w io.Writer, selection Selection, 
 				fmt.Fprintf(w, "%s %s: %s\n", e.color(string(result), colorGreen), task.ID, action.Summary)
 			case ResultSkip:
 				summary.Skipped++
+				if opts.Verbose {
+					fmt.Fprintf(w, "skip %s: %s\n", task.ID, action.Summary)
+				}
 			case ResultWarn:
 				summary.Warnings++
 				fmt.Fprintf(w, "%s %s: %s\n", e.color(string(result), colorRed), task.ID, action.Summary)
 			case ResultStop:
 				summary.Skipped++
+				if opts.Verbose {
+					fmt.Fprintf(w, "skip %s: %s\n", task.ID, action.Summary)
+				}
+			}
+		}
+		if stop {
+			break
+		}
+	}
+
+	fmt.Fprintf(
+		w,
+		"summary: %d tasks, %d actions, %d would change, %d skipped, %d warnings, %d failed\n",
+		summary.Tasks,
+		summary.Actions,
+		summary.Changed,
+		summary.Skipped,
+		summary.Warnings,
+		summary.Failed,
+	)
+	if summary.Failed > 0 {
+		return errors.New("one or more tasks failed")
+	}
+	return nil
+}
+
+func (e *Engine) runPlanSequential(ctx context.Context, w io.Writer, tasks []*Task, opts RunOptions) error {
+	summary := Summary{Tasks: len(tasks)}
+	sudo := newSudoPrompter(e)
+
+	for i, task := range tasks {
+		stop := false
+		fmt.Fprintf(w, "[%d/%d] Planning task %s: %s\n", i+1, len(tasks), task.ID, task.Name)
+		task.Actions = nil
+		thread := &starlark.Thread{Name: "boot:" + task.ID}
+		SetTask(thread, task)
+		if _, err := starlark.Call(thread, task.Run, nil, nil); err != nil {
+			summary.Failed++
+			fmt.Fprintf(w, "%s %s: %v\n", e.color("fail", colorRed), task.ID, err)
+			if !task.ContinueOnError {
+				break
+			}
+			continue
+		}
+		if err := sudo.prepare(ctx, w, []*Task{task}); err != nil {
+			return err
+		}
+		for _, action := range task.Actions {
+			summary.Actions++
+			result, err := action.Apply(ctx, true)
+			if err != nil {
+				summary.Failed++
+				fmt.Fprintf(w, "%s %s: %s: %v\n", e.color("fail", colorRed), task.ID, action.Summary, err)
+				if !task.ContinueOnError {
+					stop = true
+					break
+				}
+				continue
+			}
+			switch result {
+			case ResultChange:
+				summary.Changed++
+				fmt.Fprintf(w, "%s %s: %s\n", e.color(string(result), colorGreen), task.ID, action.Summary)
+			case ResultSkip:
+				summary.Skipped++
+				if opts.Verbose {
+					fmt.Fprintf(w, "skip %s: %s\n", task.ID, action.Summary)
+				}
+			case ResultWarn:
+				summary.Warnings++
+				fmt.Fprintf(w, "%s %s: %s\n", e.color(string(result), colorRed), task.ID, action.Summary)
+			case ResultStop:
+				summary.Skipped++
+				if opts.Verbose {
+					fmt.Fprintf(w, "skip %s: %s\n", task.ID, action.Summary)
+				}
 			}
 		}
 		if stop {
@@ -307,11 +397,11 @@ func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, op
 	if err != nil {
 		return err
 	}
-	if err := e.prepareSudo(ctx, tasks); err != nil {
-		return err
-	}
 
 	planned, summary, failures, stopOnError := e.prepare(ctx, tasks, opts)
+	if err := newSudoPrompter(e).prepare(ctx, w, tasks); err != nil {
+		return err
+	}
 	hadFailures := len(failures) > 0
 
 	if stopOnError && opts.FailFast {
@@ -331,7 +421,7 @@ func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, op
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(concurrency)
+	actions := newActionLimiter(concurrency)
 
 	var mu sync.Mutex
 
@@ -359,14 +449,22 @@ func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, op
 
 			pb.SetTitle(task.Name)
 
-			for _, action := range task.Actions {
+			applyAction := func(action Action) (Result, error) {
 				mu.Lock()
 				summary.Actions++
 				mu.Unlock()
 
-				result, err := action.Apply(ctx, opts.DryRun)
+				var (
+					result Result
+					err    error
+				)
+				if err = actions.acquire(ctx); err == nil {
+					result, err = action.Apply(ctx, opts.DryRun)
+					actions.release()
+				}
+				mu.Lock()
+				defer mu.Unlock()
 				if err != nil {
-					mu.Lock()
 					hadFailures = true
 					if !task.ContinueOnError {
 						stopOnError = true
@@ -378,16 +476,8 @@ func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, op
 						Action:   action.Summary,
 						Err:      err,
 					})
-					mu.Unlock()
-
-					if opts.FailFast && !task.ContinueOnError {
-						pb.Increment()
-						return err
-					}
-					continue
+					return result, err
 				}
-
-				mu.Lock()
 				switch result {
 				case ResultChange:
 					summary.Changed++
@@ -398,10 +488,55 @@ func (e *Engine) apply(ctx context.Context, w io.Writer, selection Selection, op
 				case ResultStop:
 					summary.Skipped++
 				}
-				mu.Unlock()
-				if result == ResultStop {
+				return result, nil
+			}
+
+			for i := 0; i < len(task.Actions); {
+				action := task.Actions[i]
+				if !action.Concurrent || concurrency == 1 {
+					result, err := applyAction(action)
+					if err != nil && opts.FailFast && !task.ContinueOnError {
+						pb.Increment()
+						return err
+					}
+					if result == ResultStop {
+						break
+					}
+					i++
+					continue
+				}
+
+				end := i + 1
+				for end < len(task.Actions) && task.Actions[end].Concurrent {
+					end++
+				}
+				batch, batchCtx := errgroup.WithContext(ctx)
+				var shouldStop atomic.Bool
+				for _, action := range task.Actions[i:end] {
+					batch.Go(func() error {
+						result, err := applyAction(action)
+						if result == ResultStop {
+							shouldStop.Store(true)
+						}
+						if err != nil && opts.FailFast && !task.ContinueOnError {
+							return err
+						}
+						select {
+						case <-batchCtx.Done():
+							return batchCtx.Err()
+						default:
+							return nil
+						}
+					})
+				}
+				if err := batch.Wait(); err != nil {
+					pb.Increment()
+					return err
+				}
+				if shouldStop.Load() {
 					break
 				}
+				i = end
 			}
 
 			pb.Increment()
@@ -433,11 +568,11 @@ func (e *Engine) applyVerbose(ctx context.Context, w io.Writer, selection Select
 	if err != nil {
 		return err
 	}
-	if err := e.prepareSudo(ctx, tasks); err != nil {
-		return err
-	}
 
 	planned, summary, failures, stopOnError := e.prepare(ctx, tasks, opts)
+	if err := newSudoPrompter(e).prepare(ctx, w, tasks); err != nil {
+		return err
+	}
 	if stopOnError && opts.FailFast {
 		e.printReport(w, summary, false)
 		e.printFailures(w, failures)
@@ -503,6 +638,15 @@ type failure struct {
 	TaskName string
 	Action   string
 	Err      error
+}
+
+func taskFailure(failures []failure, task *Task) (failure, bool) {
+	for _, failure := range failures {
+		if failure.TaskID == task.ID && failure.Action == "" {
+			return failure, true
+		}
+	}
+	return failure{}, false
 }
 
 func (e *Engine) printReport(w io.Writer, summary Summary, dryRun bool) {
@@ -620,13 +764,10 @@ func (e *Engine) runJSON(ctx context.Context, w io.Writer, selection Selection, 
 	if err != nil {
 		return err
 	}
-	if !opts.DryRun {
-		if err := e.prepareSudo(ctx, tasks); err != nil {
-			return err
-		}
-	}
-
 	planned, summary, failures, stopOnError := e.prepare(ctx, tasks, opts)
+	if err := newSudoPrompter(e).prepare(ctx, io.Discard, tasks); err != nil {
+		return err
+	}
 	report := jsonRun{DryRun: opts.DryRun, Summary: summary}
 	for _, f := range failures {
 		report.Actions = append(report.Actions, jsonAction{TaskID: f.TaskID, TaskName: f.TaskName, Error: f.Err.Error()})
@@ -703,12 +844,50 @@ func (e *Engine) colorEnabled() bool {
 	return e.Runtime == nil || e.Runtime.Getenv == nil || e.Runtime.Getenv("NO_COLOR") == ""
 }
 
-func (e *Engine) prepareSudo(ctx context.Context, tasks []*Task) error {
-	if e.Runtime == nil || !e.Runtime.NeedsSudo() {
+type actionLimiter struct {
+	ch chan struct{}
+}
+
+func newActionLimiter(limit int) actionLimiter {
+	return actionLimiter{ch: make(chan struct{}, max(limit, 1))}
+}
+
+func (l actionLimiter) acquire(ctx context.Context) error {
+	select {
+	case l.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (l actionLimiter) release() {
+	<-l.ch
+}
+
+type sudoPrompter struct {
+	engine   *Engine
+	prepared bool
+}
+
+func newSudoPrompter(engine *Engine) *sudoPrompter {
+	return &sudoPrompter{engine: engine}
+}
+
+func (p *sudoPrompter) prepare(ctx context.Context, w io.Writer, tasks []*Task) error {
+	if p.prepared || p.engine.Runtime == nil || !p.engine.Runtime.NeedsSudo() {
 		return nil
 	}
-	if !slices.ContainsFunc(tasks, func(task *Task) bool { return task.RequiresSudo }) {
+	reasons := sudoReasons(tasks)
+	if len(reasons) == 0 {
 		return nil
+	}
+	if w == nil {
+		w = io.Discard
+	}
+	fmt.Fprintln(w, "Boot requests administrator permissions to run the following tasks and actions:")
+	for _, reason := range reasons {
+		fmt.Fprintf(w, "  - %s\n", reason)
 	}
 	cmd := exec.CommandContext(ctx, "sudo", "-v")
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -718,7 +897,30 @@ func (e *Engine) prepareSudo(ctx context.Context, tasks []*Task) error {
 		}
 		return fmt.Errorf("sudo authentication failed: %w:\n%s", err, msg)
 	}
+	p.prepared = true
 	return nil
+}
+
+func sudoReasons(tasks []*Task) []string {
+	var reasons []string
+	for _, task := range tasks {
+		actions := sudoActionReasons(task)
+		if len(actions) == 0 && task.RequiresSudo {
+			reasons = append(reasons, fmt.Sprintf("task %s: %s", task.ID, task.Name))
+		}
+		reasons = append(reasons, actions...)
+	}
+	return reasons
+}
+
+func sudoActionReasons(task *Task) []string {
+	var reasons []string
+	for _, action := range task.Actions {
+		if action.RequiresSudo {
+			reasons = append(reasons, fmt.Sprintf("%s: %s", task.ID, action.Summary))
+		}
+	}
+	return reasons
 }
 
 // Selected returns tasks matching selection, topologically sorted.

--- a/cmd/boot/internal/engine_test.go
+++ b/cmd/boot/internal/engine_test.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"go.starlark.net/starlark"
 )
@@ -86,7 +88,7 @@ func TestPlanFailFastStopsAfterActionFailure(t *testing.T) {
 	}}
 
 	var out bytes.Buffer
-	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{DryRun: true, FailFast: true})
+	err := engine.Run(t.Context(), &out, Selection{}, RunOptions{DryRun: true, FailFast: true})
 	if err == nil {
 		t.Fatal("Run succeeded, want failure")
 	}
@@ -128,7 +130,7 @@ func TestApplyVerboseFailFastStopsAfterActionFailure(t *testing.T) {
 	}}
 
 	var out bytes.Buffer
-	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{Verbose: true, FailFast: true})
+	err := engine.Run(t.Context(), &out, Selection{}, RunOptions{Verbose: true, FailFast: true})
 	if err == nil {
 		t.Fatal("Run succeeded, want failure")
 	}
@@ -171,7 +173,7 @@ func TestApplyFailFastPreservesContinueOnError(t *testing.T) {
 	}}
 
 	var out bytes.Buffer
-	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{FailFast: true, Concurrency: 1})
+	err := engine.Run(t.Context(), &out, Selection{}, RunOptions{FailFast: true, Concurrency: 1})
 	if err == nil {
 		t.Fatal("Run succeeded, want failure report")
 	}
@@ -209,7 +211,7 @@ func TestApplyStopsCurrentTaskOnResultStop(t *testing.T) {
 	}}
 
 	var out bytes.Buffer
-	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{Concurrency: 1})
+	err := engine.Run(t.Context(), &out, Selection{}, RunOptions{Concurrency: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +246,7 @@ func TestPlanDoesNotStopOnResultStop(t *testing.T) {
 	}}
 
 	var out bytes.Buffer
-	err := engine.Run(context.Background(), &out, Selection{}, RunOptions{DryRun: true})
+	err := engine.Run(t.Context(), &out, Selection{}, RunOptions{DryRun: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,11 +297,251 @@ func TestPrepareSudo(t *testing.T) {
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	engine := &Engine{Runtime: &Runtime{Getenv: func(string) string { return "" }}}
-	err := engine.prepareSudo(context.Background(), []*Task{{ID: "root_task", RequiresSudo: true}})
+	var out bytes.Buffer
+	err := newSudoPrompter(engine).prepare(t.Context(), &out, []*Task{{ID: "root_task", Name: "Root task", RequiresSudo: true}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("sudo was not called: %v", err)
+	}
+	assertContains(t, out.String(), "Boot requests administrator permissions to run the following tasks and actions:", "sudo prompt")
+	assertContains(t, out.String(), "  - task root_task: Root task", "sudo prompt")
+}
+
+func TestSudoReasonsPreferActionDetails(t *testing.T) {
+	reasons := sudoReasons([]*Task{{
+		ID:           "setup_etc",
+		Name:         "Install /etc files",
+		RequiresSudo: true,
+		Actions: []Action{{
+			Summary:      "sync tree prefs/etc to /etc (sudo)",
+			RequiresSudo: true,
+		}},
+	}})
+	if len(reasons) != 1 || reasons[0] != "setup_etc: sync tree prefs/etc to /etc (sudo)" {
+		t.Fatalf("sudo reasons = %v, want action reason only", reasons)
+	}
+}
+
+func TestRunPlanPromptsForSudoOnceBeforeTasks(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("sudo is not needed when running as root")
+	}
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "sudo"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	engine := &Engine{
+		Runtime: &Runtime{Getenv: func(string) string { return "" }},
+		Tasks: []*Task{
+			{
+				ID:   "first",
+				Name: "First",
+				Run:  sudoAction("first action"),
+			},
+			{
+				ID:   "second",
+				Name: "Second",
+				Run:  sudoAction("second action"),
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	if err := engine.Run(t.Context(), &out, Selection{}, RunOptions{DryRun: true, Verbose: true}); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	prompt := "Boot requests administrator permissions to run the following tasks and actions:"
+	if strings.Count(got, prompt) != 1 {
+		t.Fatalf("sudo prompt count = %d, want 1:\n%s", strings.Count(got, prompt), got)
+	}
+	if strings.Index(got, prompt) > strings.Index(got, "[1/2] Planning task first") {
+		t.Fatalf("sudo prompt was not printed before planning tasks:\n%s", got)
+	}
+	assertContains(t, got, "  - first: first action", "sudo prompt")
+	assertContains(t, got, "  - second: second action", "sudo prompt")
+}
+
+func sudoAction(summary string) starlark.Callable {
+	return starlark.NewBuiltin("sudo", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+		AddAction(thread, Action{
+			Summary:      summary,
+			RequiresSudo: true,
+			Apply: func(context.Context, bool) (Result, error) {
+				return ResultSkip, nil
+			},
+		})
+		return starlark.None, nil
+	})
+}
+
+func TestRunPlanVerbosePrintsSkippedActions(t *testing.T) {
+	out := runSkippedActionEngine(t, RunOptions{DryRun: true, Verbose: true})
+	assertContains(t, out, "skip noop: already current", "verbose plan output")
+}
+
+func TestApplyVerbosePrintsSkippedActions(t *testing.T) {
+	out := runSkippedActionEngine(t, RunOptions{Verbose: true})
+	assertContains(t, out, "skip noop: already current", "verbose output")
+}
+
+func runSkippedActionEngine(t *testing.T, opts RunOptions) string {
+	t.Helper()
+
+	engine := &Engine{Tasks: []*Task{{
+		ID:   "noop",
+		Name: "No-op",
+		Run: starlark.NewBuiltin("noop", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+			AddAction(thread, Action{
+				Summary: "already current",
+				Apply: func(context.Context, bool) (Result, error) {
+					return ResultSkip, nil
+				},
+			})
+			return starlark.None, nil
+		}),
+	}}}
+
+	var out bytes.Buffer
+	if err := engine.Run(t.Context(), &out, Selection{}, opts); err != nil {
+		t.Fatal(err)
+	}
+	return out.String()
+}
+
+func assertContains(t *testing.T, got, want, name string) {
+	t.Helper()
+
+	if !strings.Contains(got, want) {
+		t.Fatalf("%s did not include %q:\n%s", name, want, got)
+	}
+}
+
+func TestApplyUsesGlobalConcurrentActionLimit(t *testing.T) {
+	var running atomic.Int32
+	var maxRunning atomic.Int32
+	engine := &Engine{Tasks: []*Task{
+		{
+			ID:   "repos-a",
+			Name: "repos a",
+			Run:  concurrentTestActions(&running, &maxRunning),
+		},
+		{
+			ID:   "repos-b",
+			Name: "repos b",
+			Run:  concurrentTestActions(&running, &maxRunning),
+		},
+	}}
+
+	var out bytes.Buffer
+	if err := engine.Run(t.Context(), &out, Selection{}, RunOptions{Concurrency: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if got := maxRunning.Load(); got > 2 {
+		t.Fatalf("max concurrent actions = %d, want at most 2", got)
+	}
+}
+
+func concurrentTestActions(running, maxRunning *atomic.Int32) starlark.Callable {
+	return starlark.NewBuiltin("repos", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+		for range 2 {
+			AddAction(thread, Action{
+				Summary:    "clone",
+				Concurrent: true,
+				Apply: func(context.Context, bool) (Result, error) {
+					current := running.Add(1)
+					for {
+						max := maxRunning.Load()
+						if current <= max || maxRunning.CompareAndSwap(max, current) {
+							break
+						}
+					}
+					time.Sleep(25 * time.Millisecond)
+					running.Add(-1)
+					return ResultSkip, nil
+				},
+			})
+		}
+		return starlark.None, nil
+	})
+}
+
+func TestApplyStopsAfterConcurrentStopResult(t *testing.T) {
+	var ranAfterStop atomic.Bool
+	engine := &Engine{Tasks: []*Task{{
+		ID:   "repos",
+		Name: "repos",
+		Run: starlark.NewBuiltin("repos", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+			AddAction(thread, Action{
+				Summary:    "stop",
+				Concurrent: true,
+				Apply: func(context.Context, bool) (Result, error) {
+					return ResultStop, nil
+				},
+			})
+			AddAction(thread, Action{
+				Summary:    "skip",
+				Concurrent: true,
+				Apply: func(context.Context, bool) (Result, error) {
+					return ResultSkip, nil
+				},
+			})
+			AddAction(thread, Action{
+				Summary: "must not run",
+				Apply: func(context.Context, bool) (Result, error) {
+					ranAfterStop.Store(true)
+					return ResultSkip, nil
+				},
+			})
+			return starlark.None, nil
+		}),
+	}}}
+
+	var out bytes.Buffer
+	if err := engine.Run(t.Context(), &out, Selection{}, RunOptions{Concurrency: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if ranAfterStop.Load() {
+		t.Fatal("action after concurrent ResultStop ran")
+	}
+}
+
+func TestApplyRunsConcurrentActionsInParallel(t *testing.T) {
+	var running atomic.Int32
+	var overlapped atomic.Bool
+	engine := &Engine{Tasks: []*Task{
+		{
+			ID:   "repos",
+			Name: "repos",
+			Run: starlark.NewBuiltin("repos", func(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+				for range 2 {
+					AddAction(thread, Action{
+						Summary:    "clone",
+						Concurrent: true,
+						Apply: func(context.Context, bool) (Result, error) {
+							if running.Add(1) == 2 {
+								overlapped.Store(true)
+							}
+							time.Sleep(25 * time.Millisecond)
+							running.Add(-1)
+							return ResultSkip, nil
+						},
+					})
+				}
+				return starlark.None, nil
+			}),
+		},
+	}}
+
+	var out bytes.Buffer
+	if err := engine.Run(t.Context(), &out, Selection{}, RunOptions{Concurrency: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if !overlapped.Load() {
+		t.Fatal("concurrent actions did not overlap")
 	}
 }

--- a/cmd/boot/internal/env/env.go
+++ b/cmd/boot/internal/env/env.go
@@ -104,7 +104,7 @@ func loadFile(path string) error {
 	if err != nil {
 		return err
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue

--- a/cmd/boot/internal/fetch/fetch_test.go
+++ b/cmd/boot/internal/fetch/fetch_test.go
@@ -5,7 +5,6 @@
 package fetch
 
 import (
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"net/http"
@@ -46,7 +45,7 @@ func TestFetchFile(t *testing.T) {
 	if len(task.Actions) != 1 {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -68,7 +67,7 @@ func TestFetchFile(t *testing.T) {
 		t.Errorf("got mode %o, want 0600", info.Mode().Perm())
 	}
 
-	res, err = task.Actions[0].Apply(context.Background(), false)
+	res, err = task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}

--- a/cmd/boot/internal/fs/fs.go
+++ b/cmd/boot/internal/fs/fs.go
@@ -154,29 +154,21 @@ func (m *impl) syncTree(thread *starlark.Thread, b *starlark.Builtin, args starl
 	}
 
 	boot.AddAction(thread, boot.Action{
-		Summary: summary,
+		Summary:      summary,
+		RequiresSudo: sudo,
 		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
 			if _, err := os.Stat(src); errors.Is(err, fs.ErrNotExist) && onlyIfExists {
 				return boot.ResultSkip, nil
 			} else if err != nil {
 				return "", err
 			}
-			if dryRun && sudo && m.rt.NeedsSudo() {
-				return boot.ResultChange, nil
-			}
 
-			args := []string{"-a"}
-			if owner != "" || group != "" {
-				args = append(args, "--chown="+owner+":"+group)
-			}
-			checkArgs := append([]string{"-ani"}, args[1:]...)
-			checkArgs = append(checkArgs, withTrailingSeparator(src), withTrailingSeparator(dst))
-			checkCmd := rsyncCommand(ctx, m.rt, sudo, checkArgs)
-			out, err := checkCmd.CombinedOutput()
+			args := syncTreeArgs(owner, group)
+			changed, err := syncTreeChanged(ctx, m.rt, sudo, args, src, dst)
 			if err != nil {
-				return "", boot.CommandError(checkCmd.Args, out, err)
+				return "", err
 			}
-			if len(bytes.TrimSpace(out)) == 0 {
+			if !changed {
 				return boot.ResultSkip, nil
 			}
 			if dryRun {
@@ -185,7 +177,7 @@ func (m *impl) syncTree(thread *starlark.Thread, b *starlark.Builtin, args starl
 
 			args = append(args, withTrailingSeparator(src), withTrailingSeparator(dst))
 			cmd := rsyncCommand(ctx, m.rt, sudo, args)
-			out, err = cmd.CombinedOutput()
+			out, err := cmd.CombinedOutput()
 			if err != nil {
 				return "", boot.CommandError(cmd.Args, out, err)
 			}
@@ -193,6 +185,27 @@ func (m *impl) syncTree(thread *starlark.Thread, b *starlark.Builtin, args starl
 		},
 	})
 	return starlark.None, nil
+}
+
+func syncTreeArgs(owner, group string) []string {
+	// Directory mtimes change as files are added or removed outside the recipe; do
+	// not let that churn make otherwise synchronized trees look non-idempotent.
+	args := []string{"-a", "--omit-dir-times"}
+	if owner != "" || group != "" {
+		args = append(args, "--chown="+owner+":"+group)
+	}
+	return args
+}
+
+func syncTreeChanged(ctx context.Context, rt *boot.Runtime, sudo bool, args []string, src, dst string) (bool, error) {
+	checkArgs := append([]string{"-ani"}, args[1:]...)
+	checkArgs = append(checkArgs, withTrailingSeparator(src), withTrailingSeparator(dst))
+	checkCmd := rsyncCommand(ctx, rt, sudo, checkArgs)
+	out, err := checkCmd.CombinedOutput()
+	if err != nil {
+		return false, boot.CommandError(checkCmd.Args, out, err)
+	}
+	return len(bytes.TrimSpace(out)) > 0, nil
 }
 
 func withTrailingSeparator(path string) string {

--- a/cmd/boot/internal/fs/fs_test.go
+++ b/cmd/boot/internal/fs/fs_test.go
@@ -5,10 +5,10 @@
 package fs
 
 import (
-	"context"
 	"errors"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -36,7 +36,7 @@ func TestFSDir(t *testing.T) {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
 
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestFSDir(t *testing.T) {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
 
-	res, err = task.Actions[0].Apply(context.Background(), false)
+	res, err = task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestFSFile(t *testing.T) {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
 
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestFSFile(t *testing.T) {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
 
-	res, err = task.Actions[0].Apply(context.Background(), false)
+	res, err = task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestFSFile(t *testing.T) {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
 
-	res, err = task.Actions[0].Apply(context.Background(), false)
+	res, err = task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestFSTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := task.Actions[0].Apply(context.Background(), false); err != nil {
+	if _, err := task.Actions[0].Apply(t.Context(), false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(filepath.Join(root, "out.txt"))
@@ -223,7 +223,7 @@ func TestFSChmod(t *testing.T) {
 	if len(task.Actions) != 1 {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestFSChmod(t *testing.T) {
 		t.Errorf("got mode %o, want 0600", info.Mode().Perm())
 	}
 
-	res, err = task.Actions[0].Apply(context.Background(), false)
+	res, err = task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestFSRemoveDanglingSymlink(t *testing.T) {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
 
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestFSSymlink(t *testing.T) {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
 
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -334,11 +334,70 @@ func TestFSSymlink(t *testing.T) {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
 
-	res, err = task.Actions[0].Apply(context.Background(), false)
+	res, err = task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
 	if res != boot.ResultSkip {
 		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}
+
+func TestFSSyncTreeChangeCheck(t *testing.T) {
+	if _, err := exec.LookPath("rsync"); err != nil {
+		t.Skip("rsync not found in PATH")
+	}
+
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "file.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+	m := &impl{rt: rt}
+	_, err := m.syncTree(thread, starlark.NewBuiltin("fs.sync_tree", m.syncTree), nil, []starlark.Tuple{
+		{starlark.String("source"), starlark.String(source)},
+		{starlark.String("target"), starlark.String(target)},
+	})
+	if err != nil {
+		t.Fatalf("fs.sync_tree failed: %v", err)
+	}
+	res, err := task.Actions[0].Apply(t.Context(), true)
+	if err != nil {
+		t.Fatalf("dry run failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Fatalf("dry-run before sync = %v, want %v", res, boot.ResultChange)
+	}
+	res, err = task.Actions[0].Apply(t.Context(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Fatalf("apply = %v, want %v", res, boot.ResultChange)
+	}
+	res, err = task.Actions[0].Apply(t.Context(), true)
+	if err != nil {
+		t.Fatalf("dry run after sync failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Fatalf("dry-run after sync = %v, want %v", res, boot.ResultSkip)
+	}
+
+	if err := os.WriteFile(filepath.Join(source, "file.txt"), []byte("goodbye\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = task.Actions[0].Apply(t.Context(), true)
+	if err != nil {
+		t.Fatalf("dry run after source change failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Fatalf("dry-run after source change = %v, want %v", res, boot.ResultChange)
 	}
 }

--- a/cmd/boot/internal/git/git.go
+++ b/cmd/boot/internal/git/git.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	boot "go.astrophena.name/tools/cmd/boot/internal"
 
@@ -20,14 +21,17 @@ import (
 )
 
 // Module returns the Starlark git module.
-func Module() boot.Module { return module{} }
+func Module() boot.Module { return &module{} }
 
-type module struct{}
+type module struct {
+	mu    sync.Mutex
+	repos map[string]*sync.Mutex
+}
 
-func (module) Name() string { return "git" }
+func (*module) Name() string { return "git" }
 
-func (module) Members(rt *boot.Runtime) starlark.StringDict {
-	m := &impl{rt: rt}
+func (mod *module) Members(rt *boot.Runtime) starlark.StringDict {
+	m := &impl{rt: rt, mod: mod}
 	return starlark.StringDict{
 		"clone": starlark.NewBuiltin("git.clone", m.clone),
 		"pull":  starlark.NewBuiltin("git.pull", m.pull),
@@ -36,7 +40,27 @@ func (module) Members(rt *boot.Runtime) starlark.StringDict {
 }
 
 type impl struct {
-	rt *boot.Runtime
+	rt  *boot.Runtime
+	mod *module
+}
+
+func (m *module) lockRepo(dst string) func() {
+	if m == nil {
+		return func() {}
+	}
+	m.mu.Lock()
+	if m.repos == nil {
+		m.repos = make(map[string]*sync.Mutex)
+	}
+	lock := m.repos[filepath.Clean(dst)]
+	if lock == nil {
+		lock = new(sync.Mutex)
+		m.repos[filepath.Clean(dst)] = lock
+	}
+	m.mu.Unlock()
+
+	lock.Lock()
+	return lock.Unlock
 }
 
 func (m *impl) sync(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -45,39 +69,47 @@ func (m *impl) sync(thread *starlark.Thread, b *starlark.Builtin, args starlark.
 	}
 
 	var (
-		url  string
-		dest string
+		url      string
+		dest     string
+		revision string
 	)
-	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "url", &url, "dest", &dest); err != nil {
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "url", &url, "dest", &dest, "revision?", &revision); err != nil {
 		return nil, err
 	}
 
 	dst := m.rt.ResolveTarget(dest)
+	summary := fmt.Sprintf("git sync %s to %s", url, dst)
+	if revision != "" {
+		summary += " at " + revision
+	}
 
 	boot.AddAction(thread, boot.Action{
-		Summary: fmt.Sprintf("git sync %s to %s", url, dst),
+		Summary:    summary,
+		Concurrent: true,
 		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			unlock := m.mod.lockRepo(dst)
+			defer unlock()
+
 			if _, err := os.Stat(filepath.Join(dst, ".git")); errors.Is(err, fs.ErrNotExist) {
 				if dryRun {
 					return boot.ResultChange, nil
 				}
-				if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-					return "", err
-				}
-				cmd := exec.CommandContext(ctx, "git", "clone", url, dst)
-				if err := run(cmd); err != nil {
+				if err := cloneRepository(ctx, url, dst, revision); err != nil {
 					return "", err
 				}
 				return boot.ResultChange, nil
-			}
-
-			cmd := exec.CommandContext(ctx, "git", "-C", dst, "status", "--porcelain")
-			out, err := cmd.Output()
-			if err != nil {
+			} else if err != nil {
 				return "", err
 			}
-			if len(out) > 0 {
+
+			if dirty, err := isDirty(ctx, dst); err != nil {
+				return "", err
+			} else if dirty {
 				return boot.ResultSkip, nil
+			}
+
+			if revision != "" {
+				return syncRevision(ctx, dst, revision, dryRun)
 			}
 
 			if !hasUpstream(ctx, dst) {
@@ -119,8 +151,12 @@ func (m *impl) pull(thread *starlark.Thread, b *starlark.Builtin, args starlark.
 	dst := m.rt.ResolveTarget(dest)
 
 	boot.AddAction(thread, boot.Action{
-		Summary: fmt.Sprintf("git pull %s", dst),
+		Summary:    fmt.Sprintf("git pull %s", dst),
+		Concurrent: true,
 		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			unlock := m.mod.lockRepo(dst)
+			defer unlock()
+
 			if _, err := os.Stat(filepath.Join(dst, ".git")); errors.Is(err, fs.ErrNotExist) {
 				return "", fmt.Errorf("not a git repository: %s", dst)
 			}
@@ -166,36 +202,51 @@ func (m *impl) clone(thread *starlark.Thread, b *starlark.Builtin, args starlark
 	}
 
 	var (
-		url  string
-		dest string
+		url      string
+		dest     string
+		revision string
 	)
 	if err := starlark.UnpackArgs(
 		b.Name(), args, kwargs,
 		"url", &url,
 		"dest", &dest,
+		"revision?", &revision,
 	); err != nil {
 		return nil, err
 	}
 
 	dst := m.rt.ResolveTarget(dest)
+	summary := fmt.Sprintf("git clone %s to %s", url, dst)
+	if revision != "" {
+		summary += " at " + revision
+	}
 
 	boot.AddAction(thread, boot.Action{
-		Summary: fmt.Sprintf("git clone %s to %s", url, dst),
+		Summary:    summary,
+		Concurrent: true,
 		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			unlock := m.mod.lockRepo(dst)
+			defer unlock()
+
 			if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {
-				return boot.ResultSkip, nil
+				if revision == "" {
+					return boot.ResultSkip, nil
+				}
+				if dirty, err := isDirty(ctx, dst); err != nil {
+					return "", err
+				} else if dirty {
+					return boot.ResultSkip, nil
+				}
+				return syncRevision(ctx, dst, revision, dryRun)
+			} else if !errors.Is(err, fs.ErrNotExist) {
+				return "", err
 			}
 
 			if dryRun {
 				return boot.ResultChange, nil
 			}
 
-			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-				return "", err
-			}
-
-			cmd := exec.CommandContext(ctx, "git", "clone", url, dst)
-			if err := run(cmd); err != nil {
+			if err := cloneRepository(ctx, url, dst, revision); err != nil {
 				return "", err
 			}
 
@@ -264,4 +315,69 @@ func gitRevision(ctx context.Context, dst, rev string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func cloneRepository(ctx context.Context, url, dst, revision string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "git", "clone", url, dst)
+	if err := run(cmd); err != nil {
+		return err
+	}
+	if revision == "" {
+		return nil
+	}
+	return checkoutRevision(ctx, dst, revision)
+}
+
+func isDirty(ctx context.Context, dst string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dst, "status", "--porcelain")
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return len(out) > 0, nil
+}
+
+func syncRevision(ctx context.Context, dst, revision string, dryRun bool) (boot.Result, error) {
+	current, err := gitRevision(ctx, dst, "HEAD")
+	if err != nil {
+		return "", err
+	}
+	resolved, err := resolveRevision(ctx, dst, revision)
+	if err == nil && current == resolved {
+		return boot.ResultSkip, nil
+	}
+	if dryRun {
+		return boot.ResultChange, nil
+	}
+	if err := fetchRepository(ctx, dst); err != nil {
+		return "", err
+	}
+	resolved, err = resolveRevision(ctx, dst, revision)
+	if err != nil {
+		return "", err
+	}
+	if current == resolved {
+		return boot.ResultSkip, nil
+	}
+	if err := checkoutRevision(ctx, dst, resolved); err != nil {
+		return "", err
+	}
+	return boot.ResultChange, nil
+}
+
+func fetchRepository(ctx context.Context, dst string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", dst, "fetch", "--tags", "--prune", "origin")
+	return run(cmd)
+}
+
+func checkoutRevision(ctx context.Context, dst, revision string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", dst, "checkout", "--detach", revision)
+	return run(cmd)
+}
+
+func resolveRevision(ctx context.Context, dst, revision string) (string, error) {
+	return gitRevision(ctx, dst, revision+"^{commit}")
 }

--- a/cmd/boot/internal/git/git_test.go
+++ b/cmd/boot/internal/git/git_test.go
@@ -5,12 +5,12 @@
 package git
 
 import (
-	"context"
 	"errors"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	boot "go.astrophena.name/tools/cmd/boot/internal"
@@ -51,7 +51,7 @@ func TestGitClone(t *testing.T) {
 	if len(task.Actions) != 1 {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestGitClone(t *testing.T) {
 	if len(task.Actions) != 1 {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
-	res, err = task.Actions[0].Apply(context.Background(), false)
+	res, err = task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestGitSync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sync failed: %v", err)
 	}
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestGitSync(t *testing.T) {
 		t.Fatalf("destination .git: %v", err)
 	}
 
-	res, err = task.Actions[0].Apply(context.Background(), false)
+	res, err = task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -188,11 +188,81 @@ func TestGitPullAlreadyCurrent(t *testing.T) {
 	if len(task.Actions) != 1 {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
 	if res != boot.ResultSkip {
 		t.Errorf("got result %v, want %v", res, boot.ResultSkip)
+	}
+}
+
+func TestGitSyncRevision(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote")
+	if err := os.Mkdir(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, remote, "init", "--bare")
+
+	work := filepath.Join(root, "work")
+	if err := os.Mkdir(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, work, "init")
+	testutil.RunGit(t, work, "config", "user.email", "test@example.com")
+	testutil.RunGit(t, work, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, work, "add", "README.md")
+	testutil.RunGit(t, work, "commit", "-m", "one")
+	first := strings.TrimSpace(testutil.RunGitOutput(t, work, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RunGit(t, work, "commit", "-am", "two")
+	testutil.RunGit(t, work, "branch", "-M", "main")
+	testutil.RunGit(t, work, "remote", "add", "origin", remote)
+	testutil.RunGit(t, work, "push", "-u", "origin", "main")
+	testutil.RunGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	rt := &boot.Runtime{Root: root}
+	task, thread := testutil.TaskThread("test")
+	m := &impl{rt: rt}
+	dest := filepath.Join(root, "local")
+	_, err := m.sync(thread, starlark.NewBuiltin("git.sync", m.sync), nil, []starlark.Tuple{
+		{starlark.String("url"), starlark.String(remote)},
+		{starlark.String("dest"), starlark.String(dest)},
+		{starlark.String("revision"), starlark.String(first)},
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	res, err := task.Actions[0].Apply(t.Context(), false)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if res != boot.ResultChange {
+		t.Errorf("got result %v, want %v", res, boot.ResultChange)
+	}
+	got := strings.TrimSpace(testutil.RunGitOutput(t, dest, "rev-parse", "HEAD"))
+	if got != first {
+		t.Fatalf("HEAD = %s, want %s", got, first)
+	}
+	branch := strings.TrimSpace(testutil.RunGitOutput(t, dest, "branch", "--show-current"))
+	if branch != "" {
+		t.Fatalf("branch = %q, want detached HEAD", branch)
+	}
+	res, err = task.Actions[0].Apply(t.Context(), true)
+	if err != nil {
+		t.Fatalf("dry-run apply failed: %v", err)
+	}
+	if res != boot.ResultSkip {
+		t.Errorf("got dry-run result %v, want %v", res, boot.ResultSkip)
 	}
 }

--- a/cmd/boot/internal/golang/golang_test.go
+++ b/cmd/boot/internal/golang/golang_test.go
@@ -5,7 +5,6 @@
 package golang
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -72,14 +71,14 @@ func TestGoInstallLocalConditions(t *testing.T) {
 		t.Fatalf("got %d actions, want 2", len(task.Actions))
 	}
 
-	res, err := task.Actions[0].Apply(context.Background(), true)
+	res, err := task.Actions[0].Apply(t.Context(), true)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
 	if res != boot.ResultChange {
 		t.Errorf("got result %v, want %v", res, boot.ResultChange)
 	}
-	res, err = task.Actions[1].Apply(context.Background(), true)
+	res, err = task.Actions[1].Apply(t.Context(), true)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}
@@ -94,7 +93,7 @@ func TestProxyUpToDateFixedVersion(t *testing.T) {
 		Module:  "example.com/tool",
 		Version: "v1.2.3",
 	}
-	upToDate, err := proxyUpToDate(context.Background(), "example.com/tool@v1.2.3", info, nil)
+	upToDate, err := proxyUpToDate(t.Context(), "example.com/tool@v1.2.3", info, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +117,7 @@ func TestLatestModuleUsesProxy(t *testing.T) {
 	defer server.Close()
 	goProxyURL = server.URL
 
-	info, err := latestModule(context.Background(), "example.com/hello")
+	info, err := latestModule(t.Context(), "example.com/hello")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,10 +156,10 @@ func TestLatestCacheFetchesConcurrently(t *testing.T) {
 	goProxyURL = server.URL
 
 	cache := newLatestCache([]string{"example.com/one", "example.com/two"})
-	if _, err := cache.Get(context.Background(), "example.com/one"); err != nil {
+	if _, err := cache.Get(t.Context(), "example.com/one"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := cache.Get(context.Background(), "example.com/two"); err != nil {
+	if _, err := cache.Get(t.Context(), "example.com/two"); err != nil {
 		t.Fatal(err)
 	}
 	if maxInFlight.Load() < 2 {
@@ -192,7 +191,7 @@ func TestLocalUpToDate(t *testing.T) {
 	testutil.RunGit(t, root, "commit", "-m", "initial")
 	head := strings.TrimSpace(testutil.RunGitOutput(t, root, "rev-parse", "HEAD"))
 
-	upToDate, err := localUpToDate(context.Background(), root, goBuildInfo{
+	upToDate, err := localUpToDate(t.Context(), root, goBuildInfo{
 		Settings: map[string]string{
 			"vcs.revision": head,
 			"vcs.modified": "false",
@@ -208,7 +207,7 @@ func TestLocalUpToDate(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	upToDate, err = localUpToDate(context.Background(), root, goBuildInfo{
+	upToDate, err = localUpToDate(t.Context(), root, goBuildInfo{
 		Settings: map[string]string{
 			"vcs.revision": head,
 			"vcs.modified": "false",

--- a/cmd/boot/internal/packages/packages.go
+++ b/cmd/boot/internal/packages/packages.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -137,6 +138,13 @@ func (m *impl) update(thread *starlark.Thread, b *starlark.Builtin, args starlar
 			m.mod.pkgMu.Lock()
 			defer m.mod.pkgMu.Unlock()
 
+			updates, err := pm.updates(ctx)
+			if err != nil {
+				return "", err
+			}
+			if len(updates) == 0 {
+				return boot.ResultSkip, nil
+			}
 			if dryRun {
 				return boot.ResultChange, nil
 			}
@@ -239,6 +247,7 @@ type packageManager struct {
 	missing     func(context.Context, []string) ([]string, error)
 	explicit    func(context.Context) ([]string, error)
 	installArgv func([]string) []string
+	updates     func(context.Context) ([]string, error)
 	update      func(context.Context) error
 }
 
@@ -252,6 +261,104 @@ func sudoArgs(rt *boot.Runtime, args ...string) []string {
 		return append([]string{"sudo"}, args...)
 	}
 	return args
+}
+
+func pacmanUpdates(ctx context.Context, rt *boot.Runtime) ([]string, error) {
+	// Follow checkupdates' safe-update pattern: synchronize a separate pacman
+	// database, then compare the installed local database against that copy. This
+	// avoids running pacman -Sy against the system database without immediately
+	// upgrading, which can leave the host in a partial-upgrade-prone state.
+	dbpath, err := pacmanCheckDBPath(rt)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(dbpath, 0o755); err != nil {
+		return nil, err
+	}
+	local := filepath.Join(dbpath, "local")
+	// pacman -Qu needs the installed package database. Like checkupdates, keep
+	// using the system "local" database through a symlink while storing synced
+	// repository databases in boot's cache directory.
+	if _, err := os.Lstat(local); errors.Is(err, os.ErrNotExist) {
+		pacmanDBPath := pacmanSystemDBPath(ctx)
+		if err := os.Symlink(filepath.Join(pacmanDBPath, "local"), local); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
+
+	// Sync only the cached database. fakeroot lets pacman create root-owned
+	// database metadata in the cache without requiring actual privileges.
+	cmd := exec.CommandContext(ctx, "fakeroot", "--", "pacman", "-Sy", "--disable-sandbox-filesystem", "--dbpath", dbpath, "--logfile", os.DevNull)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, boot.CommandError(cmd.Args, out, err)
+	}
+
+	// Query pending upgrades against the cached sync database. pacman exits 1
+	// when no upgrades are available, which is a successful no-op for boot.
+	cmd = exec.CommandContext(ctx, "pacman", "-Qu", "--dbpath", dbpath)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			return nil, err
+		}
+	}
+
+	var updates []string
+	for line := range strings.SplitSeq(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		// checkupdates suppresses bracketed pacman notes such as ignored packages;
+		// they are not actionable updates for pkg.update.
+		if line == "" || strings.Contains(line, "[") && strings.Contains(line, "]") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			updates = append(updates, fields[0])
+		}
+	}
+	return updates, nil
+}
+
+func pacmanCheckDBPath(rt *boot.Runtime) (string, error) {
+	cacheHome := ""
+	if rt != nil && rt.Getenv != nil {
+		cacheHome = rt.Getenv("XDG_CACHE_HOME")
+	}
+	if cacheHome == "" {
+		home := ""
+		if rt != nil {
+			home = rt.Home
+		}
+		if home == "" && rt != nil && rt.Getenv != nil {
+			home = rt.Getenv("HOME")
+		}
+		if home == "" {
+			var err error
+			home, err = os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+		}
+		cacheHome = filepath.Join(home, ".cache")
+	}
+	return filepath.Join(cacheHome, "boot", "pacman"), nil
+}
+
+func pacmanSystemDBPath(ctx context.Context) string {
+	cmd := exec.CommandContext(ctx, "pacman-conf", "DBPath")
+	out, err := cmd.Output()
+	if err != nil {
+		return "/var/lib/pacman"
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "/var/lib/pacman"
+	}
+	return path
 }
 
 func packageManagerByName(rt *boot.Runtime, name string) (packageManager, error) {
@@ -295,6 +402,9 @@ func packageManagerByName(rt *boot.Runtime, name string) (packageManager, error)
 			installArgv: func(packages []string) []string {
 				return sudoArgs(rt, append([]string{"apt", "install", "-y"}, packages...)...)
 			},
+			updates: func(context.Context) ([]string, error) {
+				return []string{"system"}, nil
+			},
 			update: func(ctx context.Context) error {
 				var cmdLine string
 				if rt.NeedsSudo() {
@@ -334,6 +444,9 @@ func packageManagerByName(rt *boot.Runtime, name string) (packageManager, error)
 			},
 			installArgv: func(packages []string) []string {
 				return sudoArgs(rt, append([]string{"pacman", "-S", "--noconfirm", "--needed"}, packages...)...)
+			},
+			updates: func(ctx context.Context) ([]string, error) {
+				return pacmanUpdates(ctx, rt)
 			},
 			update: func(ctx context.Context) error {
 				args := sudoArgs(rt, "pacman", "-Syu", "--noconfirm")

--- a/cmd/boot/internal/packages/packages_test.go
+++ b/cmd/boot/internal/packages/packages_test.go
@@ -5,8 +5,8 @@
 package packages
 
 import (
-	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	boot "go.astrophena.name/tools/cmd/boot/internal"
@@ -30,7 +30,7 @@ done
 	if err != nil {
 		t.Fatal(err)
 	}
-	missing, err := pm.missing(context.Background(), []string{"installed", "missing"})
+	missing, err := pm.missing(t.Context(), []string{"installed", "missing"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ exit 0
 	if err != nil {
 		t.Fatal(err)
 	}
-	missing, err := pm.missing(context.Background(), []string{"installed", "missing"})
+	missing, err := pm.missing(t.Context(), []string{"installed", "missing"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,8 +81,83 @@ esac
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := pm.update(context.Background()); err != nil {
+	if err := pm.update(t.Context()); err != nil {
 		t.Fatalf("update failed: %v", err)
+	}
+}
+
+func TestPackageManagerPacmanUpdates(t *testing.T) {
+	bin := t.TempDir()
+	systemDB := filepath.Join(t.TempDir(), "pacman")
+	if err := os.MkdirAll(filepath.Join(systemDB, "local"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteCommand(t, bin, "pacman-conf", "#!/bin/sh\necho "+systemDB+"\n")
+	testutil.WriteCommand(t, bin, "fakeroot", `#!/bin/sh
+if [ "$1" != "--" ] || [ "$2" != "pacman" ] || [ "$3" != "-Sy" ]; then
+	exit 1
+fi
+exit 0
+`)
+	testutil.WriteCommand(t, bin, "pacman", `#!/bin/sh
+case "$1" in
+-Qu)
+	echo "linux 1-1 -> 1-2"
+	echo "ignored 1-1 -> 1-2 [ignored]"
+	exit 0 ;;
+*) exit 1 ;;
+esac
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cache := t.TempDir()
+	rt := &boot.Runtime{Getenv: func(key string) string {
+		if key == "XDG_CACHE_HOME" {
+			return cache
+		}
+		return os.Getenv(key)
+	}}
+
+	updates, err := pacmanUpdates(t.Context(), rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updates) != 1 || updates[0] != "linux" {
+		t.Fatalf("updates = %v, want [linux]", updates)
+	}
+	if _, err := os.Lstat(filepath.Join(cache, "boot", "pacman", "local")); err != nil {
+		t.Fatalf("local database link was not created: %v", err)
+	}
+}
+
+func TestPackageManagerPacmanUpdatesNone(t *testing.T) {
+	bin := t.TempDir()
+	systemDB := filepath.Join(t.TempDir(), "pacman")
+	if err := os.MkdirAll(filepath.Join(systemDB, "local"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteCommand(t, bin, "pacman-conf", "#!/bin/sh\necho "+systemDB+"\n")
+	testutil.WriteCommand(t, bin, "fakeroot", "#!/bin/sh\nexit 0\n")
+	testutil.WriteCommand(t, bin, "pacman", `#!/bin/sh
+case "$1" in
+-Qu) exit 1 ;;
+*) exit 1 ;;
+esac
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cache := t.TempDir()
+	rt := &boot.Runtime{Getenv: func(key string) string {
+		if key == "XDG_CACHE_HOME" {
+			return cache
+		}
+		return os.Getenv(key)
+	}}
+
+	updates, err := pacmanUpdates(t.Context(), rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("updates = %v, want none", updates)
 	}
 }
 
@@ -107,7 +182,7 @@ exit 1
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := pm.update(context.Background()); err != nil {
+	if err := pm.update(t.Context()); err != nil {
 		t.Fatalf("update failed: %v", err)
 	}
 }

--- a/cmd/boot/internal/rescue/rescue.go
+++ b/cmd/boot/internal/rescue/rescue.go
@@ -6,7 +6,9 @@ package rescue
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -178,7 +180,7 @@ type outputBuild struct {
 
 func rescueOutputBuilds(dir string) ([]outputBuild, error) {
 	entries, err := os.ReadDir(dir)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {

--- a/cmd/boot/internal/rescue/rescue_test.go
+++ b/cmd/boot/internal/rescue/rescue_test.go
@@ -5,7 +5,8 @@
 package rescue
 
 import (
-	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -59,7 +60,7 @@ done
 		writeFile(t, filepath.Join(root, name))
 	}
 
-	if err := pruneOutput(context.Background(), &boot.Runtime{Getenv: func(string) string { return "termux" }}, root, 2); err != nil {
+	if err := pruneOutput(t.Context(), &boot.Runtime{Getenv: func(string) string { return "termux" }}, root, 2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -73,7 +74,7 @@ done
 			t.Fatalf("%s was removed: %v", name, err)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(root, "arch-linux-rescue_202603010102.efi")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(root, "arch-linux-rescue_202603010102.efi")); !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("old build still exists: %v", err)
 	}
 }

--- a/cmd/boot/internal/shell/shell_test.go
+++ b/cmd/boot/internal/shell/shell_test.go
@@ -5,7 +5,6 @@
 package shell
 
 import (
-	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -115,7 +114,7 @@ func TestShellRun(t *testing.T) {
 				t.Fatalf("got %d actions, want 1", len(task.Actions))
 			}
 
-			res, err := task.Actions[0].Apply(context.Background(), tc.dryRun)
+			res, err := task.Actions[0].Apply(t.Context(), tc.dryRun)
 			if err != nil {
 				t.Fatalf("apply failed: %v", err)
 			}

--- a/cmd/boot/internal/ssh/ssh_test.go
+++ b/cmd/boot/internal/ssh/ssh_test.go
@@ -5,7 +5,6 @@
 package ssh
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +35,7 @@ func TestSSHKeySkipsExistingKey(t *testing.T) {
 	if len(task.Actions) != 1 {
 		t.Fatalf("got %d actions, want 1", len(task.Actions))
 	}
-	res, err := task.Actions[0].Apply(context.Background(), false)
+	res, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatalf("apply failed: %v", err)
 	}

--- a/cmd/boot/internal/systemd/systemd_test.go
+++ b/cmd/boot/internal/systemd/systemd_test.go
@@ -5,7 +5,6 @@
 package systemd
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +41,7 @@ esac
 		t.Fatal(err)
 	}
 
-	got, err := task.Actions[0].Apply(context.Background(), true)
+	got, err := task.Actions[0].Apply(t.Context(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +85,7 @@ esac
 		t.Fatal(err)
 	}
 
-	got, err := task.Actions[0].Apply(context.Background(), false)
+	got, err := task.Actions[0].Apply(t.Context(), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/boot/main.go
+++ b/cmd/boot/main.go
@@ -62,7 +62,7 @@ func (a *app) Flags(fs *flag.FlagSet) {
 	fs.Var(&a.only, "only", "Run only the specified task ID. May be repeated.")
 	fs.Var(&a.skip, "skip", "Skip the specified task ID. May be repeated.")
 	fs.Var(&a.tags, "tag", "Run tasks with the specified tag. May be repeated.")
-	fs.IntVar(&a.concurrency, "j", 1, "Number of tasks to run in parallel.")
+	fs.IntVar(&a.concurrency, "j", 1, "Number of tasks and eligible actions to run in parallel.")
 }
 
 func (a *app) Run(ctx context.Context) error {

--- a/cmd/boot/modules.md
+++ b/cmd/boot/modules.md
@@ -113,7 +113,10 @@ the package manager, so no-op runs are fast.
 
 ### `pkg.update()`
 
-Update the package manager's database and upgrade installed packages.
+Update the package manager's database and upgrade installed packages. With
+`pacman`, boot first checks for pending updates using a separate database under
+`$XDG_CACHE_HOME/boot/pacman` (or `~/.cache/boot/pacman`) and skips when the
+system is already current.
 
 ### `pkg.check_explicit_packages(packages)`
 
@@ -176,19 +179,22 @@ first when systemd reports that a daemon reload is needed.
 
 ## `git`
 
-### `git.clone(url, dest)`
+### `git.clone(url, dest, revision = "")`
 
-Ensure `url` is cloned to `dest`. Relative `dest` is resolved against the recipe
-root; paths beginning with `~/` use `HOME`.
+Ensure `url` is cloned to `dest`. If `revision` is set, check out that concrete
+revision as a detached HEAD. Relative `dest` is resolved against the recipe root;
+paths beginning with `~/` use `HOME`.
 
 ### `git.pull(dest)`
 
 Ensure the git repository at `dest` is up-to-date. It skips if the repository is dirty or has no upstream tracking branch.
 
-### `git.sync(url, dest)`
+### `git.sync(url, dest, revision = "")`
 
 Ensure `url` is cloned to `dest`, or fetch and fast-forward pull the existing
-repository when it is clean and has an upstream tracking branch.
+repository when it is clean and has an upstream tracking branch. If `revision` is
+set, fetch and check out that concrete revision as a detached HEAD instead of
+fast-forwarding the upstream branch.
 
 ## `go`
 

--- a/cmd/mdserve/main_test.go
+++ b/cmd/mdserve/main_test.go
@@ -53,7 +53,7 @@ func setupTestContext(t *testing.T) (context.Context, *bytes.Buffer) {
 		Logger: slog.New(h),
 		Level:  level,
 	}
-	ctx := logger.Put(context.Background(), l)
+	ctx := logger.Put(t.Context(), l)
 	return ctx, &buf
 }
 

--- a/cmd/tgfeed/internal/admin/idle_test.go
+++ b/cmd/tgfeed/internal/admin/idle_test.go
@@ -17,7 +17,7 @@ func TestTracker(t *testing.T) {
 	os.Setenv("EXIT_IDLE_TIME", "50ms")
 	t.Cleanup(func() { os.Unsetenv("EXIT_IDLE_TIME") })
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	tracker := newTracker(cancel, func() bool { return true })

--- a/cmd/tgfeed/internal/ctxsleep/ctxsleep_test.go
+++ b/cmd/tgfeed/internal/ctxsleep/ctxsleep_test.go
@@ -20,14 +20,14 @@ func TestSleep(t *testing.T) {
 	}{
 		"elapsed": {
 			context: func() context.Context {
-				return context.Background()
+				return t.Context()
 			},
 			duration: 1 * time.Millisecond,
 			want:     true,
 		},
 		"canceled": {
 			context: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
+				ctx, cancel := context.WithCancel(t.Context())
 				cancel()
 				return ctx
 			},

--- a/cmd/tgfeed/internal/stats/store.go
+++ b/cmd/tgfeed/internal/stats/store.go
@@ -397,7 +397,7 @@ func sqliteURIWithPragma(uri string, pragma string) string {
 }
 
 func execScript(ctx context.Context, db *sql.DB, script string) error {
-	for _, stmt := range strings.Split(script, ";") {
+	for stmt := range strings.SplitSeq(script, ";") {
 		stmt = strings.TrimSpace(stmt)
 		if stmt == "" {
 			continue

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.astrophena.name/tools
 
-go 1.26.3
+go 1.26.4
 
 require (
 	crawshaw.dev/jsonfile v0.0.0-20240206193014-699d1dad804e

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6,7 +6,6 @@ package store
 
 import (
 	"bytes"
-	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -27,7 +26,7 @@ func TestJSONFile(t *testing.T) {
 }
 
 func testStore(t *testing.T, s Store) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	value1 := []byte(`"value1"`)
 	value2 := []byte(`123`)


### PR DESCRIPTION
Improve boot planning and maintenance actions by adding clearer sudo prompting, verbose skipped-action output, globally limited concurrent actions, idempotent pacman update checks, idempotent rsync tree checks, and safer concurrent git handling.

Also apply Go modernization updates from go fix across touched tests and helpers.

Assisted-by: GPT-5.5
