### PR TITLE
cmd/boot: add program update protocol

### DIFF
--- a/cmd/boot/internal/program/doc.go
+++ b/cmd/boot/internal/program/doc.go
@@ -1,0 +1,6 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+// Package program implements the Starlark module for protocol-driven program updates.
+package program

--- a/cmd/boot/internal/program/program.go
+++ b/cmd/boot/internal/program/program.go
@@ -1,0 +1,96 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package program
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+
+	"go.starlark.net/starlark"
+)
+
+const checkFlag = "-check"
+
+// Module returns the Starlark program module.
+func Module() boot.Module { return module{} }
+
+type module struct{}
+
+func (module) Name() string { return "program" }
+
+func (module) Members(*boot.Runtime) starlark.StringDict {
+	m := new(impl)
+	return starlark.StringDict{
+		"update": starlark.NewBuiltin("program.update", m.update),
+	}
+}
+
+type impl struct{}
+
+func (m *impl) update(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if err := boot.RequireTask(thread, b); err != nil {
+		return nil, err
+	}
+
+	var list *starlark.List
+	if err := starlark.UnpackArgs(b.Name(), args, kwargs, "argv", &list); err != nil {
+		return nil, err
+	}
+	argv, err := unpackArgv(list)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", b.Name(), err)
+	}
+
+	boot.AddAction(thread, boot.Action{
+		Summary: "update program: " + strings.Join(argv, " "),
+		Apply: func(ctx context.Context, dryRun bool) (boot.Result, error) {
+			checkArgv := append(slices.Clone(argv), checkFlag)
+			out, err := boot.CommandOutput(ctx, "", checkArgv...)
+			if err != nil {
+				return "", err
+			}
+			switch strings.TrimSpace(string(out)) {
+			case "false":
+				return boot.ResultSkip, nil
+			case "true":
+				if dryRun {
+					return boot.ResultChange, nil
+				}
+				if err := boot.RunCommand(ctx, "", argv...); err != nil {
+					return "", err
+				}
+				return boot.ResultChange, nil
+			default:
+				return "", fmt.Errorf("%s returned invalid update check result %q", strings.Join(checkArgv, " "), strings.TrimSpace(string(out)))
+			}
+		},
+	})
+	return starlark.None, nil
+}
+
+func unpackArgv(list *starlark.List) ([]string, error) {
+	if list == nil || list.Len() == 0 {
+		return nil, fmt.Errorf("argv cannot be empty")
+	}
+	argv := make([]string, 0, list.Len())
+	for i := range list.Len() {
+		arg, ok := starlark.AsString(list.Index(i))
+		if !ok {
+			return nil, fmt.Errorf("argv[%d] is not a string", i)
+		}
+		if arg == "" {
+			return nil, fmt.Errorf("argv[%d] cannot be empty", i)
+		}
+		if arg == checkFlag || strings.HasPrefix(arg, checkFlag+"=") {
+			return nil, fmt.Errorf("argv[%d] uses reserved flag %s", i, checkFlag)
+		}
+		argv = append(argv, arg)
+	}
+	return argv, nil
+}

--- a/cmd/boot/internal/program/program_test.go
+++ b/cmd/boot/internal/program/program_test.go
@@ -1,0 +1,164 @@
+// © 2026 Ilya Mateyko. All rights reserved.
+// Use of this source code is governed by the ISC
+// license that can be found in the LICENSE.md file.
+
+package program
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	boot "go.astrophena.name/tools/cmd/boot/internal"
+	"go.astrophena.name/tools/cmd/boot/internal/testutil"
+	"go.starlark.net/starlark"
+)
+
+func TestUpdate(t *testing.T) {
+	cases := map[string]struct {
+		check     string
+		dryRun    bool
+		want      boot.Result
+		wantApply bool
+	}{
+		"applies needed update": {
+			check:     "true",
+			want:      boot.ResultChange,
+			wantApply: true,
+		},
+		"plans needed update": {
+			check:  "true",
+			dryRun: true,
+			want:   boot.ResultChange,
+		},
+		"skips current program": {
+			check: "false",
+			want:  boot.ResultSkip,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			log := filepath.Join(t.TempDir(), "program.log")
+			t.Setenv("PROGRAM_CHECK", tc.check)
+			t.Setenv("PROGRAM_LOG", log)
+			testutil.Commands(t, map[string]string{
+				"updater": `#!/bin/sh
+echo "$@" >> "$PROGRAM_LOG"
+if [ "$2" = "-check" ]; then
+	printf '%s\n' "$PROGRAM_CHECK"
+fi
+`,
+			})
+
+			h := testutil.NewTask(t, "test")
+			m := new(impl)
+			action := h.EmitOne("program.update", m.update, starlark.Tuple{starlark.NewList([]starlark.Value{
+				starlark.String("updater"),
+				starlark.String("update"),
+			})}, nil)
+			got, err := action.Apply(t.Context(), tc.dryRun)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("result = %s, want %s", got, tc.want)
+			}
+			output, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Contains(string(output), "\nupdate\n"); got != tc.wantApply {
+				t.Fatalf("apply call = %v, want %v:\n%s", got, tc.wantApply, output)
+			}
+		})
+	}
+}
+
+func TestUpdateRejectsInvalidCheckResult(t *testing.T) {
+	testutil.Commands(t, map[string]string{
+		"updater": "#!/bin/sh\necho maybe\n",
+	})
+	h := testutil.NewTask(t, "test")
+	m := new(impl)
+	action := h.EmitOne("program.update", m.update, starlark.Tuple{starlark.NewList([]starlark.Value{
+		starlark.String("updater"),
+	})}, nil)
+	_, err := action.Apply(t.Context(), true)
+	if err == nil || !strings.Contains(err.Error(), `invalid update check result "maybe"`) {
+		t.Fatalf("error = %v, want invalid check result", err)
+	}
+}
+
+func TestUpdateReportsCommandFailures(t *testing.T) {
+	cases := map[string]struct {
+		script string
+		want   string
+	}{
+		"check failure": {
+			script: "#!/bin/sh\necho check failed >&2\nexit 1\n",
+			want:   "check failed",
+		},
+		"apply failure": {
+			script: `#!/bin/sh
+if [ "$1" = "-check" ]; then
+	echo true
+	exit 0
+fi
+echo apply failed >&2
+exit 1
+`,
+			want: "apply failed",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			testutil.Commands(t, map[string]string{"updater": tc.script})
+			h := testutil.NewTask(t, "test")
+			m := new(impl)
+			action := h.EmitOne("program.update", m.update, starlark.Tuple{starlark.NewList([]starlark.Value{
+				starlark.String("updater"),
+			})}, nil)
+			_, err := action.Apply(t.Context(), false)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpdateRejectsInvalidArgv(t *testing.T) {
+	cases := map[string]struct {
+		argv *starlark.List
+		want string
+	}{
+		"empty list": {
+			argv: starlark.NewList(nil),
+			want: "argv cannot be empty",
+		},
+		"empty argument": {
+			argv: starlark.NewList([]starlark.Value{starlark.String("")}),
+			want: "argv[0] cannot be empty",
+		},
+		"non-string argument": {
+			argv: starlark.NewList([]starlark.Value{starlark.MakeInt(1)}),
+			want: "argv[0] is not a string",
+		},
+		"reserved flag": {
+			argv: starlark.NewList([]starlark.Value{starlark.String("updater"), starlark.String("-check")}),
+			want: "uses reserved flag -check",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			task := &boot.Task{ID: "test"}
+			thread := &starlark.Thread{Name: "test"}
+			boot.SetTask(thread, task)
+			m := new(impl)
+			_, err := m.update(thread, starlark.NewBuiltin("program.update", m.update), starlark.Tuple{tc.argv}, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want mention %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/boot/main.go
+++ b/cmd/boot/main.go
@@ -27,6 +27,7 @@ import (
 	bootgo "go.astrophena.name/tools/cmd/boot/internal/golang"
 	bootpkg "go.astrophena.name/tools/cmd/boot/internal/packages"
 	bootpacman "go.astrophena.name/tools/cmd/boot/internal/pacman"
+	bootprogram "go.astrophena.name/tools/cmd/boot/internal/program"
 	bootrescue "go.astrophena.name/tools/cmd/boot/internal/rescue"
 	bootshell "go.astrophena.name/tools/cmd/boot/internal/shell"
 	bootssh "go.astrophena.name/tools/cmd/boot/internal/ssh"
@@ -210,6 +211,7 @@ func (a *app) engine(env *cli.Env) (*boot.Engine, error) {
 			bootfs.Module(),
 			bootpkg.Module(),
 			bootpacman.Module(),
+			bootprogram.Module(),
 			bootshell.Module(),
 			bootgit.Module(),
 			bootgo.Module(),

--- a/cmd/boot/modules.md
+++ b/cmd/boot/modules.md
@@ -150,6 +150,20 @@ Warn when explicitly installed native packages are not listed in `packages`.
 Warn when `.pacnew` files exist under `/etc`, grouping files managed by
 `managed_etc` separately from unmanaged files and showing short diffs.
 
+## `program`
+
+### `program.update(argv)`
+
+Update a program through Boot's check protocol. `argv` is the command that
+applies the update and is executed directly without a shell. To check whether
+an update is needed, Boot appends `-check`; the program must print only `true`
+or `false` to standard output. When the result is `true`, planning reports a
+change and applying runs the original command.
+
+The `-check` invocation must be read-only. Diagnostics may be written to
+standard error; a failed check, failed update, or any other standard output is
+reported as an action failure.
+
 ## `rescue`
 
 ### `rescue.update(source, esp_dir = "/efi/EFI/Linux", keep = 3)`


### PR DESCRIPTION
## Summary

- add a generic `program.update(argv)` Starlark module
- probe updates by appending `-check` and accepting strict Boolean output
- run the original argv only when the program reports an update
- document the protocol and cover current, pending, invalid, and failure cases

## Validation

- `go tool pre-commit`
- focused read-only Boot plan using freshly built Boot and Dungeon binaries