### PR TITLE
go.mod: update Go and base

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.astrophena.name/tools
 
-go 1.26.5
+go 1.26.6
 
 require (
 	crawshaw.dev/jsonfile v0.0.0-20240206193014-699d1dad804e
@@ -12,7 +12,7 @@ require (
 	github.com/mmcdole/gofeed v1.4.0
 	github.com/tailscale/sqlite v0.0.0-20260306200437-15a02b90c606
 	github.com/tobischo/gokeepasslib/v3 v3.7.0
-	go.astrophena.name/base v0.23.2-0.20260711190559-47229d27c5d7
+	go.astrophena.name/base v0.23.2
 	go.starlark.net v0.0.0-20260326113308-fadfc96def35
 	golang.org/x/mod v0.38.0
 	golang.org/x/sync v0.22.0
@@ -37,7 +37,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mmcdole/goxpp/v2 v2.0.0 // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect
-	github.com/restic/chunker v0.4.0 // indirect
+	github.com/restic/chunker v0.5.0 // indirect
 	github.com/tobischo/argon2 v0.1.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260218203240-3dfff04db8fa // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0
 github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/restic/chunker v0.4.0 h1:YUPYCUn70MYP7VO4yllypp2SjmsRhRJaad3xKu1QFRw=
-github.com/restic/chunker v0.4.0/go.mod h1:z0cH2BejpW636LXw0R/BGyv+Ey8+m9QGiOanDHItzyw=
+github.com/restic/chunker v0.5.0 h1:1y+ut0MBduzxODJ298rhQCtESoEpj8v1hTydZlKaE1Y=
+github.com/restic/chunker v0.5.0/go.mod h1:z0cH2BejpW636LXw0R/BGyv+Ey8+m9QGiOanDHItzyw=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -65,8 +65,8 @@ github.com/tobischo/gokeepasslib/v3 v3.7.0 h1:MZKx72JkkQdElHr4gOQlnLF92B6i+Bv4Kw
 github.com/tobischo/gokeepasslib/v3 v3.7.0/go.mod h1:Lvv7/e6Eys07pEjQfpx52W9ptuDRiM4Osiz3m897tQg=
 github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
 github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.astrophena.name/base v0.23.2-0.20260711190559-47229d27c5d7 h1:Z3pKoyYZoG/9axmortSJG6M9HsUtns8aryZtQv/MevY=
-go.astrophena.name/base v0.23.2-0.20260711190559-47229d27c5d7/go.mod h1:1LZIYSNBdxtJbxVbaT0RH7b4sFuBVx2FwbMlKbOrKGI=
+go.astrophena.name/base v0.23.2 h1:hoVt7Ihvmnqh2uax/Fvpifs8C4Fw+rwRlZH3uR182cs=
+go.astrophena.name/base v0.23.2/go.mod h1:g5vM3slUV2BALLHtMn6PzgQu5y6CorOV76KnHfGnYoc=
 go.starlark.net v0.0.0-20260326113308-fadfc96def35 h1:VYAqieSOJNxBDX8KJneTAwvdf4J4zRDE2u+UFXtt9h4=
 go.starlark.net v0.0.0-20260326113308-fadfc96def35/go.mod h1:Iue6g6iirlfLoVi/DYCi5/x0h/bAOuWF3dULTKpt2Vo=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=


### PR DESCRIPTION
## Summary
- update Go from 1.26.5 to 1.26.6
- update `go.astrophena.name/base` to `v0.23.2`
- run `go mod tidy`

## Verification
- `go get -u go@latest go.astrophena.name/base@v0.23.2`
- `go mod tidy`

*Generated with the `latestgo` tool. I am only a tool. If this was a mistake, the mistake was upstream of me.*